### PR TITLE
Disable onboarding if migrating from Block Lab

### DIFF
--- a/php/Admin/Onboarding.php
+++ b/php/Admin/Onboarding.php
@@ -47,12 +47,9 @@ class Onboarding extends ComponentAbstract {
 
 	/**
 	 * Runs during plugin activation.
-	 *
-	 * If users migrated from Block Lab, there will be a query var to not display onboarding.
-	 * They will already have blocks, so this doesn't seem needed.
 	 */
 	public function plugin_activation() {
-		if ( empty( $_REQUEST[ self::QUERY_VAR_DISABLE_ONBOARDING ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! filter_input( INPUT_GET, self::QUERY_VAR_DISABLE_ONBOARDING ) ) {
 			$this->add_dummy_data();
 			$this->prepare_welcome_notice();
 		}

--- a/tests/php/Unit/Admin/TestOnboarding.php
+++ b/tests/php/Unit/Admin/TestOnboarding.php
@@ -6,6 +6,10 @@
  */
 
 use Genesis\CustomBlocks\Admin\Onboarding;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\setup;
+use function Brain\Monkey\tearDown;
+
 
 /**
  * Tests for class Onboarding.
@@ -26,8 +30,19 @@ class TestOnboarding extends \WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+		setup();
 		$this->instance = new Onboarding();
 		$this->instance->set_plugin( genesis_custom_blocks() );
+	}
+
+	/**
+	 * Teardown.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		tearDown();
+		parent::tearDown();
 	}
 
 	/**
@@ -57,7 +72,14 @@ class TestOnboarding extends \WP_UnitTestCase {
 	 * @covers \Genesis\CustomBlocks\Admin\Onboarding::plugin_activation()
 	 */
 	public function test_plugin_activation_onboarding_disabled() {
-		$_REQUEST[ Onboarding::QUERY_VAR_DISABLE_ONBOARDING ] = true;
+		expect( 'filter_input' )
+			->once()
+			->with(
+				INPUT_GET,
+				Onboarding::QUERY_VAR_DISABLE_ONBOARDING
+			)
+			->andReturn( true );
+
 		$this->instance->plugin_activation();
 
 		$this->assertEmpty( get_option( 'genesis_custom_blocks_example_post_id' ) );


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* When migrating from Block Lab to GCB, this prevents the onboarding from displaying
* Block Lab adds query var to disable this in https://github.com/getblocklab/block-lab/pull/629


#### Testing instructions
1. `wp transient delete genesis_custom_blocks_show_welcome # just in case`
2. `wp option delete genesis_custom_blocks_example_post_id`
3. checkout the branch from https://github.com/getblocklab/block-lab/pull/629 and follow its [testing instructions]( https://github.com/getblocklab/block-lab/pull/629#issue-439492116)
4. Expected: On clicking 'Activate Genesis Custom Blocks,' there should not be onboarding:

![no-onboarding-no](https://user-images.githubusercontent.com/4063887/87103073-92239d80-c219-11ea-8780-1eef0d8d725f.gif)

5. To reverse the migration: https://github.com/getblocklab/block-lab/pull/629#issuecomment-655846402
