### PR TITLE
Handle GCB being activated when BL is active

### DIFF
--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -88,15 +88,6 @@ if ( ! function_exists( 'register_block_type' ) ) {
 	}
 }
 
-// Load some helpers.
-require_once __DIR__ . '/php/Helpers.php';
-
-// Load block API helpers.
-require_once __DIR__ . '/php/BlockApi.php';
-
-// Handle deprecated functions.
-require_once __DIR__ . '/php/Deprecated.php';
-
 /**
  * Get the plugin object.
  *

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -101,6 +101,8 @@ class Plugin extends PluginAbstract {
 
 	/**
 	 * Gets whether there is a conflict from another plugin having the same functions.
+	 *
+	 * @return bool Whether there is a conflict.
 	 */
 	public function is_plugin_conflict() {
 		if ( isset( $this->is_conflict ) ) {

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -100,7 +100,7 @@ class Plugin extends PluginAbstract {
 	}
 
 	/**
-	 * Gets whether there is a conflict from another plugin having the same function.
+	 * Gets whether there is a conflict from another plugin having the same functions.
 	 */
 	public function is_plugin_conflict() {
 		if ( isset( $this->is_conflict ) ) {

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -52,11 +52,7 @@ class Plugin extends PluginAbstract {
 	 */
 	public function init() {
 		if ( $this->is_plugin_conflict() ) {
-			add_action(
-				'admin_notices',
-				[ $this, 'plugin_conflict_notice' ]
-			);
-
+			add_action( 'admin_notices', [ $this, 'plugin_conflict_notice' ] );
 			return;
 		}
 

--- a/tests/patchwork.json
+++ b/tests/patchwork.json
@@ -2,6 +2,7 @@
     "redefinable-internals": [
         "chmod",
         "filter_input",
+        "function_exists",
         "is_uploaded_file",
         "move_uploaded_file"
     ]

--- a/tests/php/Unit/Blocks/TestLoader.php
+++ b/tests/php/Unit/Blocks/TestLoader.php
@@ -14,6 +14,8 @@ use Genesis\CustomBlocks\Blocks\Loader;
  */
 class TestLoader extends AbstractTemplate {
 
+	use TestingHelper;
+
 	/**
 	 * The instance to test.
 	 *

--- a/tests/php/Unit/Helpers/AbstractTemplate.php
+++ b/tests/php/Unit/Helpers/AbstractTemplate.php
@@ -116,20 +116,6 @@ abstract class AbstractTemplate extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Sets a protected property's value.
-	 *
-	 * @param string $property The name of the property to get.
-	 * @param mixed  $value The value to set.
-	 * @throws ReflectionException For a non-accessible property.
-	 */
-	public function set_protected_property( $property, $value ) {
-		$reflection = new ReflectionObject( $this->instance );
-		$property   = $reflection->getProperty( $property );
-		$property->setAccessible( true );
-		$property->setValue( $this->instance, $value );
-	}
-
-	/**
 	 * Gets the directories that block templates and CSS files could be in.
 	 */
 	public function create_block_template_directories() {

--- a/tests/php/Unit/Helpers/TestingHelper.php
+++ b/tests/php/Unit/Helpers/TestingHelper.php
@@ -44,4 +44,18 @@ trait TestingHelper {
 		$transient_value = $is_valid ? 'valid' : 'key-invalid';
 		set_transient( Subscription::SUBSCRIPTION_STATUS_TRANSIENT_NAME, $transient_value );
 	}
+
+	/**
+	 * Sets a protected property's value.
+	 *
+	 * @param string $property The name of the property to get.
+	 * @param mixed  $value    The value to set.
+	 * @throws ReflectionException For a non-accessible property.
+	 */
+	public function set_protected_property( $property, $value ) {
+		$reflection = new ReflectionObject( $this->instance );
+		$property   = $reflection->getProperty( $property );
+		$property->setAccessible( true );
+		$property->setValue( $this->instance, $value );
+	}
 }

--- a/tests/php/Unit/TestPlugin.php
+++ b/tests/php/Unit/TestPlugin.php
@@ -132,7 +132,7 @@ class TestPlugin extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test is_plugin_conflict when it's expected to be true.
+	 * Test is_plugin_conflict.
 	 *
 	 * @dataProvider get_data_is_conflict
 	 * @covers \Genesis\CustomBlocks\Util::get_template_locations()
@@ -141,7 +141,7 @@ class TestPlugin extends \WP_UnitTestCase {
 	 * @param bool $expected        The expected return value.
 	 * @throws ReflectionException  For a non-accessible property.
 	 */
-	public function test_is_plugin_conflict_true( $function_exists, $expected ) {
+	public function test_is_plugin_conflict( $function_exists, $expected ) {
 		$this->set_protected_property( 'is_conflict', null );
 		expect( 'function_exists' )
 			->andReturn( $function_exists );

--- a/tests/php/Unit/TestUtil.php
+++ b/tests/php/Unit/TestUtil.php
@@ -54,9 +54,15 @@ class TestUtil extends AbstractTemplate {
 	 * Like genesis_custom_blocks()->is_pro().
 	 *
 	 * @covers \Genesis\CustomBlocks\Util::is_pro()
+	 * @throws ReflectionException If the property is not available.
 	 */
 	public function test_is_pro() {
 		$plugin_instance = new Plugin();
+		$reflection      = new ReflectionObject( $plugin_instance );
+		$property        = $reflection->getProperty( 'is_conflict' );
+		$property->setAccessible( true );
+		$property->setValue( $plugin_instance, false );
+
 		$plugin_instance->init();
 		$plugin_instance->plugin_loaded();
 


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Before, there was a PHP error on activating BL while GCB is active:
<img width="493" alt="activate-bl" src="https://user-images.githubusercontent.com/4063887/87591526-15c40b00-c6ae-11ea-82bf-52b05fb463fd.png">

* If BL is active while GCB is, this disables bootstrapping GCB
* Displays a notice on every `/wp-admin` screen


#### Testing instructions
1. Activate Block Lab
2. Activate Genesis Custom Blocks
3. Expected: There is a notice that appears on every /wp-admin page:
>It looks like Block Lab is active. Please deactivate it, as Genesis Custom Blocks will not work while it is active.

<img width="854" alt="bl-active-here" src="https://user-images.githubusercontent.com/4063887/87590580-9eda4280-c6ac-11ea-9b04-48021f9a7c2a.png">
4. Expected: There shouldn't be a Custom Blocks menu item:
<img width="407" alt="no-cust-b" src="https://user-images.githubusercontent.com/4063887/87590678-ce894a80-c6ac-11ea-99af-51b3b23fdcb6.png">

----
Ideally, BL would be able to prevent itself from loading in `block-lab.php` if GCB is active, using `function_exists( 'block_field' )` 

But it looks like BL usually loads before GCB in my local, maybe because it's earlier in the alphabet. Also, [is_plugin_active()](https://developer.wordpress.org/reference/functions/is_plugin_active/) isn't defined by the time `block-lab.php` or `genesis-custom-blocks.php` run.

And it doesn't look like you can use [register_activation_hook](https://developer.wordpress.org/reference/functions/register_activation_hook/) to block GCB from activating if BL is active.

The reason to display the notice on every page is that GCB will be useless. It won't load any class other than `Plugin`, and won't even have its menu:

<img width="319" alt="will-not-have-menu" src="https://user-images.githubusercontent.com/4063887/88094821-ca9c7300-cb59-11ea-8249-a904579c5a63.png">

Also, I mentioned 'Block Lab' in the notice because they need to know which plugin to deactivate. I could also add a button in the notice to deactivate it, like in the migration notice: https://github.com/getblocklab/block-lab/pull/635#issuecomment-653620467
