### PR TITLE
Remove isLarge attribute from buttons for WP 5.5

### DIFF
--- a/js/blocks/components/image.js
+++ b/js/blocks/components/image.js
@@ -101,7 +101,6 @@ const Image = withSelect( ( select, ownProps ) => {
 						{ ! isUploading && (
 							<>
 								<FormFileUpload
-									isLarge
 									disabled={ !! isUploading }
 									onChange={ ( event ) => {
 										const files = event.target.files;
@@ -122,7 +121,6 @@ const Image = withSelect( ( select, ownProps ) => {
 									render={ ( { open } ) => (
 										<div className="components-media-library-button">
 											<Button
-												isLarge
 												disabled={ !! isUploading }
 												className="editor-media-placeholder__button"
 												onClick={ open }
@@ -139,7 +137,6 @@ const Image = withSelect( ( select, ownProps ) => {
 			) }
 			{ imageSrc && (
 				<Button
-					isLarge
 					disabled={ !! isUploading }
 					className="gcb-image__remove"
 					onClick={ removeImage }


### PR DESCRIPTION
Prevents the “React does not recognize the `isLarge` prop on a DOM element” console warning in WP 5.5 caused by the `isLarge` attribute being removed in 5.5.

<img width="657" alt="Screenshot 2020-08-07 at 16 59 35" src="https://user-images.githubusercontent.com/647669/89658901-660a4380-d8cf-11ea-91aa-626a0291cefa.png">

#### Testing instructions
Under WP 5.5:

1. Create a custom block containing an image field.
2. Add the custom block to a page.
3. Click the block to edit its fields. There should be no console warnings (used to be present due to the “Upload” and “Media Library” buttons).
4. Add an image and dismiss the image popover to return to the editor.
5. There should be no warning in the console (from the “Remove” button).

#### See
- Removal of `isLarge`: https://github.com/WordPress/gutenberg/pull/23239
- Note about `isLarge` having no effect in the first place due to missing styles: https://github.com/WordPress/gutenberg/issues/16541#issuecomment-645336060
