### PR TITLE
Remove the wptests password in wp-tests-config.php

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           MYSQL_DATABASE: youremptytestdbnamehere
           MYSQL_HOST: 127.0.0.1
           MYSQL_USER: yourusernamehere
-          MYSQL_PASSWORD: yourpasswordhere
+          MYSQL_PASSWORD: <insert password here>
           MYSQL_ROOT_PASSWORD: wordpress
     steps:
       - run:
@@ -67,6 +67,7 @@ jobs:
             git clone git://develop.git.wordpress.org/ wordpress-develop
             cp wordpress-develop/wp-tests-config-sample.php wordpress-develop/wp-tests-config.php
             sed -i 's/localhost/127.0.0.1/g' wordpress-develop/wp-tests-config.php
+            sed -i 's/yourpasswordhere/<insert password here>/g' wordpress-develop/wp-tests-config.php
       - run: mkdir -p *PLUGIN_PATH
       - checkout:
           path: *PLUGIN_PATH

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -118,7 +118,7 @@ install_test_suite() {
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/<insert password here>/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
 	fi
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -118,7 +118,7 @@ install_test_suite() {
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/<insert password here>/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
 	fi
 

--- a/tests/wp-tests-config.php
+++ b/tests/wp-tests-config.php
@@ -22,7 +22,7 @@ define( 'WP_DEBUG', true );
 define( 'DB_HOST', 'tests-mysql' );
 define( 'DB_NAME', 'wptests' );
 define( 'DB_USER', 'wptests' );
-define( 'DB_PASSWORD', 'wptests' );
+define( 'DB_PASSWORD', '<insert password here>' );
 
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );


### PR DESCRIPTION

<!--- Please summarize this PR in the title above -->

#### Changes
* This is probably more secure, as this new password is less likely to be used.

#### Testing instructions
* Not needed, as long as CircleCI passes