### PR TITLE
Ensure the "Let's get started" link appears

### DIFF
--- a/php/Admin/Onboarding.php
+++ b/php/Admin/Onboarding.php
@@ -149,15 +149,11 @@ class Onboarding extends ComponentAbstract {
 			<h2><span role="image" aria-label="<?php esc_attr_e( 'Waving hand emoji', 'genesis-custom-blocks' ); ?>">👋</span> <?php esc_html_e( 'Hi, and welcome!', 'genesis-custom-blocks' ); ?></h2>
 			<p class="intro"><?php esc_html_e( 'Genesis Custom Blocks makes it easy to build your own blocks for the WordPress editor.', 'genesis-custom-blocks' ); ?></p>
 			<p><strong><?php esc_html_e( 'Want to see how it\'s done?', 'genesis-custom-blocks' ); ?></strong> <?php esc_html_e( 'Here\'s one we prepared earlier.', 'genesis-custom-blocks' ); ?></p>
-			<?php
-			edit_post_link(
-				__( 'Let\'s get started!', 'genesis-custom-blocks' ),
-				'<p>',
-				'</p>',
-				$example_post_id,
-				'button button--white button_cta'
-			);
-			?>
+			<p>
+				<a class="button button--white button_cta" href="<?php echo esc_url( $this->get_edit_link( $example_post_id ) ); ?>">
+					<?php esc_html_e( 'Let\'s get started!', 'genesis-custom-blocks' ); ?>
+				</a>
+			</p>
 			<p class="ps"><?php esc_html_e( 'P.S. We don\'t like to nag. This message won\'t be shown again.', 'genesis-custom-blocks' ); ?></p>
 			<p class="ps">
 				<?php
@@ -171,6 +167,31 @@ class Onboarding extends ComponentAbstract {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Gets the link to edit a post.
+	 *
+	 * A forked and simplified version of get_edit_post_link().
+	 *
+	 * @param string|int $post_id The ID of the post.
+	 * @return string|null The URL to edit the post.
+	 */
+	public function get_edit_link( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return null;
+		}
+
+		$post_type_object = get_post_type_object( $post->post_type );
+		if ( empty( $post_type_object->_edit_link ) ) {
+			return null;
+		}
+
+		$link = admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=edit', $post->ID ) );
+
+		/** This filter is documented in wp-includes/link-template.php */
+		return apply_filters( 'get_edit_post_link', $link, $post->ID, 'display' );
 	}
 
 	/**

--- a/tests/php/Unit/Admin/TestOnboarding.php
+++ b/tests/php/Unit/Admin/TestOnboarding.php
@@ -71,7 +71,7 @@ class TestOnboarding extends \WP_UnitTestCase {
 			'<div class="genesis-custom-blocks-welcome genesis-custom-blocks-notice notice is-dismissible">',
 			$output
 		);
-		$this->assertContains( "post.php?post={$post_id}&amp;action=edit", $output );
+		$this->assertContains( strval( $post_id ), $output );
 	}
 
 	/**

--- a/tests/php/Unit/Admin/TestOnboarding.php
+++ b/tests/php/Unit/Admin/TestOnboarding.php
@@ -41,6 +41,62 @@ class TestOnboarding extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test show_welcome_notice when it should not display.
+	 *
+	 * @covers \Genesis\CustomBlocks\Admin\Onboarding::show_welcome_notice()
+	 */
+	public function test_show_welcome_notice_does_not_display() {
+		ob_start();
+		$this->instance->show_welcome_notice();
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	/**
+	 * Test show_welcome_notice when it should display.
+	 *
+	 * @covers \Genesis\CustomBlocks\Admin\Onboarding::show_welcome_notice()
+	 */
+	public function test_show_welcome_notice_should_display() {
+		$post_id = $this->factory()->post->create( [ 'post_type' => 'genesis_custom_block' ] );
+		update_option(
+			Onboarding::OPTION_NAME,
+			$post_id
+		);
+
+		ob_start();
+		$this->instance->show_welcome_notice();
+		$output = ob_get_clean();
+
+		$this->assertContains(
+			'<div class="genesis-custom-blocks-welcome genesis-custom-blocks-notice notice is-dismissible">',
+			$output
+		);
+		$this->assertContains( "post.php?post={$post_id}&amp;action=edit", $output );
+	}
+
+	/**
+	 * Test get_edit_link when the post ID is not for a post.
+	 *
+	 * @covers \Genesis\CustomBlocks\Admin\Onboarding::get_edit_link()
+	 */
+	public function test_get_edit_link_no_post() {
+		$this->assertEmpty( $this->instance->get_edit_link( 123456789 ) );
+	}
+
+	/**
+	 * Test get_edit_link when there is a valid post.
+	 *
+	 * @covers \Genesis\CustomBlocks\Admin\Onboarding::get_edit_link()
+	 */
+	public function test_get_edit_link_with_post() {
+		$post_id = $this->factory()->post->create( [ 'post_type' => 'genesis_custom_block' ] );
+		$this->assertContains(
+			"post.php?post={$post_id}&amp;action=edit",
+			$this->instance->get_edit_link( $post_id )
+		);
+	}
+
+	/**
 	 * Test plugin_activation.
 	 *
 	 * @covers \Genesis\CustomBlocks\Admin\Onboarding::plugin_activation()


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Creates a custom method to output the "Let's get started" link

#### Background
Before, `edit_post_link()` didn't echo anything because [in get_edit_post_link()](https://github.com/WordPress/wordpress-develop/blob/a0b40ebd6a50386c8e47a8c41206748fa46b2844/src/wp-includes/link-template.php#L1378),
`current_user_can( 'edit_post', $post->ID )` was `false`.

I don't know why it was `false`. 

#### Testing instructions
In my local, the only way I could reproduce it was creating a new WP instance, and this issue only appeared the first time I activated GCB.

1. Comment out [this line](https://github.com/studiopress/genesis-custom-blocks/blob/86c0d6c4b8c2ad5fc160632f6f44ee950c7e615c/php/Admin/Onboarding.php#L360) or delete all of your GCB blocks
1. Deactivate GCB
1. Activate GCB
1. Expected: The "Let's get started" link should appear:

<img width="1138" alt="link-should-now-appear" src="https://user-images.githubusercontent.com/4063887/91501053-66707b80-e88a-11ea-9342-791d9b34ef89.png">

Fixes https://github.com/getblocklab/block-lab/issues/509
