### PR TITLE
Update the production build process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,8 @@ The plugin versions should follow [Semantic Versioning](https://semver.org/#sema
 1. [Create a release](https://github.com/studiopress/genesis-custom-blocks/releases/new), targeting whatever branch you chose in step 1.
 1. Upload the `.zip` file you created to the release page.
 1. The 'Tag version' should be the plugin version, like `1.0.0`.
-1. There will be a `package/trunk/` directory from running `gulp` earlier. Use this to commit the new plugin version to the wp.org SVN repo.
+1. There will be a `package/trunk/` directory from running `gulp` earlier, along with a tag directory `/package/x.x.x/`, with `x.x.x` being the version number.
+1. Commit both of those directories to the wp.org SVN repo.
 1. Do `./bin/tag-built.sh`
 1. This will create a built tag of the plugin and push it. Then, other plugins or entire sites can require the plugin as a Composer dependency.
 1. If this release was for a release branch, like `1.0`, open a PR from that branch to `develop`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ The plugin versions should follow [Semantic Versioning](https://semver.org/#sema
 ### Release Procedure
 
 1. `checkout` locally whatever branch you want to release. It could be `develop`, or a release branch like `1.0`. 
-1. Do `npm run gulp`, and you'll see `package/genesis-custom-blocks.zip`.
+1. Do `npm run gulp`, and you'll see `package/genesis-custom-blocks.x.x.x.zip`.
 1. Smoke test that `.zip` file.
 1. [Create a release](https://github.com/studiopress/genesis-custom-blocks/releases/new), targeting whatever branch you chose in step 1.
 1. Upload the `.zip` file you created to the release page.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: trunk
+Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 

--- a/bin/verify-versions.php
+++ b/bin/verify-versions.php
@@ -18,6 +18,14 @@ if ( 'cli' !== php_sapi_name() ) {
 
 $versions = [];
 
+$readme_md = file_get_contents( dirname( __FILE__ ) . '/../README.md' );
+if ( ! preg_match( '/Stable tag:\s+(?P<version>\S+)/i', $readme_md, $matches ) ) {
+	echo "Could not find stable tag in readme\n";
+	exit( 1 );
+}
+
+$versions['readme.txt#stable-tag'] = $matches['version'];
+
 $plugin_file = file_get_contents( dirname( __FILE__ ) . '/../genesis-custom-blocks.php' );
 if ( ! preg_match( '/\*\s*Version:\s*(?P<version>\d+\.\d+(?:.\d+)?(-\w+)?)/', $plugin_file, $matches ) ) {
 	echo "Could not find version in main plugin file metadata\n";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,12 +103,17 @@ gulp.task( 'clean:bundle', function () {
 		'package/trunk/CONTRIBUTING.md',
 		'package/trunk/webpack.config.js',
 		'package/trunk/.github',
+		'package/trunk/SHASUMS*',
 		'package/prepare',
 	] );
 } );
 
+gulp.task( 'copy:tag', function () {
+	return run( 'export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); cp -r package/trunk package/$BUILD_VERSION' ).exec();
+} )
+
 gulp.task( 'create:zip', function () {
-	return run( 'if [ -e genesis-custom-blocks.zip ]; then rm genesis-custom-blocks.zip; fi; cd package/trunk; pwd; zip -r ../genesis-custom-blocks.zip .; cd ..; echo "ZIP of build: $(pwd)/genesis-custom-blocks.zip"' ).exec();
+	return run( 'cp -r package/trunk package/genesis-custom-blocks; export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); cd package; pwd; zip -r genesis-custom-blocks.$BUILD_VERSION.zip genesis-custom-blocks/; echo "ZIP of build: $(pwd)/genesis-custom-blocks.$BUILD_VERSION.zip"; rm -rf genesis-custom-blocks' ).exec();
 } )
 
 gulp.task( 'default', gulp.series(
@@ -123,5 +128,6 @@ gulp.task( 'default', gulp.series(
 	'wporg:trunk',
 	'version',
 	'clean:bundle',
+	'copy:tag',
 	'create:zip'
 ) );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,8 +45,7 @@ gulp.task( 'bundle', function () {
 
 gulp.task( 'remove:bundle', function () {
 	return del( [
-		'package/trunk',
-		'package/assets',
+		'package',
 	] );
 } );
 


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Makes this plugin's production build process more like the Pro one
* Not better or worse, but it'd be hard to keep track of 2 different build processes
* Uses a Stable tag of a version like `1.0.0`, not `trunk`
* When doing `npm run gulp`, this now creates `package/1.0.0`. This is so we can push the tag to the wp.org SVN repo.

#### Testing instructions
1. `npm run gulp`
1. Expected: there's a `package/1.0.0/` directory and a `package/genesis-custom-blocks-1.0.0.zip` file