### PR TITLE
Fix SVN build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ gulp.task( 'version', function () {
 } )
 
 gulp.task( 'install:dependencies', function () {
-	return run( 'composer install -o --no-dev && npm install' ).exec();
+	return run( 'composer install -o --no-dev' ).exec();
 } )
 
 gulp.task( 'run:build', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,9 @@ gulp.task( 'bundle', function () {
 
 gulp.task( 'remove:bundle', function () {
 	return del( [
-		'package',
+		'package/assets/*',
+		'package/tags/*',
+		'package/trunk/*',
 	] );
 } );
 


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Prevents removing the entire `package/` directory that had the SVN repo
* Like John mentioned, this created a problem, as `svn co` created a package directory, then this deleted it.

#### Testing instructions
1. `npm run gulp` 
1. Expected: This never deleted `package/` or `package/trunk/`