### PR TITLE
Address a fatal error when BL 1.5.6 is also active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ Plugin released!
 * Easily create custom blocks
 * 13 fields to add
 * Simple templating, with PHP files
+
+## 1.0.1 - 2020-09-01 ###
+
+Fix an error if Block Lab 1.5.6 is also active
+
+* Fixes an error with Block Lab 1.5.6, where it defines functions twice

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -54,5 +54,4 @@ genesis_custom_blocks()
 	->init();
 
 add_action( 'plugins_loaded', [ genesis_custom_blocks(), 'plugin_loaded' ] );
-add_action( 'plugins_loaded', [ genesis_custom_blocks(), 'require_helpers' ], 11 );
 add_action( 'plugins_loaded', [ genesis_custom_blocks(), 'require_deprecated' ], 11 );

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -54,4 +54,5 @@ genesis_custom_blocks()
 	->init();
 
 add_action( 'plugins_loaded', [ genesis_custom_blocks(), 'plugin_loaded' ] );
+add_action( 'plugins_loaded', [ genesis_custom_blocks(), 'require_helpers' ], 11 );
 add_action( 'plugins_loaded', [ genesis_custom_blocks(), 'require_deprecated' ], 11 );

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-custom-blocks",
   "title": "Genesis Custom Blocks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Genesis Custom Blocks",
   "license": "GPL-2.0-or-later",

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -96,7 +96,6 @@ class Plugin extends PluginAbstract {
 		require_once __DIR__ . '/BlockApi.php';
 	}
 
-
 	/**
 	 * Requires helper functions.
 	 */
@@ -121,10 +120,6 @@ class Plugin extends PluginAbstract {
 	 * An admin notice for another plugin being active.
 	 */
 	public function plugin_conflict_notice() {
-		if ( ! current_user_can( 'deactivate_plugins' ) ) {
-			return;
-		}
-
 		$plugin_file      = 'block-lab/block-lab.php';
 		$deactivation_url = add_query_arg(
 			[

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -90,7 +90,7 @@ class Plugin extends PluginAbstract {
 	}
 
 	/**
-	 * Require the API functions.
+	 * Requires the API functions.
 	 */
 	private function require_api() {
 		require_once __DIR__ . '/BlockApi.php';
@@ -150,7 +150,7 @@ class Plugin extends PluginAbstract {
 		</style>
 		<div id="gcb-conflict-notice" class="notice notice-error gcb-notice-conflict">
 			<div class="gcb-conflict-copy">
-				<p><?php esc_html_e( 'It looks like Block Lab is active. Please deactivate it or migrate, as it will not work while Genesis Custom Blocks is active.', 'genesis-custom-blocks' ); ?></p>
+				<p><?php esc_html_e( 'It looks like Block Lab is active. Please deactivate it, as it will not work while Genesis Custom Blocks is active.', 'genesis-custom-blocks' ); ?></p>
 			</div>
 			<?php
 			if ( current_user_can( 'deactivate_plugins' ) ) :

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -150,7 +150,7 @@ class Plugin extends PluginAbstract {
 		</style>
 		<div id="gcb-conflict-notice" class="notice notice-error gcb-notice-conflict">
 			<div class="gcb-conflict-copy">
-				<p><?php esc_html_e( 'It looks like Block Lab is active. Please deactivate it, as it will not work while Genesis Custom Blocks is active.', 'genesis-custom-blocks' ); ?></p>
+				<p><?php esc_html_e( 'It looks like Block Lab is active. Please upgrade, so you can migrate to Genesis Custom Blocks.', 'genesis-custom-blocks' ); ?></p>
 			</div>
 			<?php
 			if ( current_user_can( 'deactivate_plugins' ) ) :

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -74,6 +74,7 @@ class Plugin extends PluginAbstract {
 	public function plugin_loaded() {
 		$this->admin = new Admin();
 		$this->register_component( $this->admin );
+		$this->require_api();
 		$this->require_helpers();
 	}
 
@@ -89,6 +90,14 @@ class Plugin extends PluginAbstract {
 	}
 
 	/**
+	 * Require the API functions.
+	 */
+	private function require_api() {
+		require_once __DIR__ . '/BlockApi.php';
+	}
+
+
+	/**
 	 * Requires helper functions.
 	 */
 	private function require_helpers() {
@@ -96,7 +105,6 @@ class Plugin extends PluginAbstract {
 			add_action( 'admin_notices', [ $this, 'plugin_conflict_notice' ] );
 		} else {
 			require_once __DIR__ . '/Helpers.php';
-			require_once __DIR__ . '/BlockApi.php';
 		}
 	}
 
@@ -106,7 +114,7 @@ class Plugin extends PluginAbstract {
 	 * @return bool Whether there is a conflict.
 	 */
 	public function is_plugin_conflict() {
-		return function_exists( 'block_field' ) && function_exists( 'block_value' );
+		return function_exists( 'block_field' ) || function_exists( 'block_value' );
 	}
 
 	/**
@@ -116,13 +124,6 @@ class Plugin extends PluginAbstract {
 		if ( ! current_user_can( 'deactivate_plugins' ) ) {
 			return;
 		}
-
-		wp_enqueue_style(
-			'block-lab-plugin-conflict-notice-style',
-			$this->get_url( 'css/admin.conflict-notice.css' ),
-			[],
-			$this->get_version()
-		);
 
 		$plugin_file      = 'block-lab/block-lab.php';
 		$deactivation_url = add_query_arg(
@@ -137,14 +138,29 @@ class Plugin extends PluginAbstract {
 		);
 
 		?>
-		<div id="bl-conflict-notice" class="notice notice-error bl-notice-conflict">
-			<div class="bl-conflict-copy">
+		<style>
+			.gcb-notice-conflict {
+				display: flex;
+				padding-top: 0.2rem;
+				padding-bottom: 0.2rem;
+			}
+
+			.gcb-notice-conflict .gcb-conflict-copy {
+				margin-right: auto;
+			}
+
+			.gcb-notice-conflict .gcb-link-deactivate {
+				margin: auto 0.2rem;
+			}
+		</style>
+		<div id="gcb-conflict-notice" class="notice notice-error gcb-notice-conflict">
+			<div class="gcb-conflict-copy">
 				<p><?php esc_html_e( 'It looks like Block Lab is active. Please deactivate it or migrate, as it will not work while Genesis Custom Blocks is active.', 'genesis-custom-blocks' ); ?></p>
 			</div>
 			<?php
 			if ( current_user_can( 'deactivate_plugins' ) ) :
 				?>
-				<a href="<?php echo esc_url( $deactivation_url ); ?>" class="bl-link-deactivate button button-primary">
+				<a href="<?php echo esc_url( $deactivation_url ); ?>" class="gcb-link-deactivate button button-primary">
 					<?php echo esc_html_x( 'Deactivate', 'plugin', 'genesis-custom-blocks' ); ?>
 				</a>
 			<?php endif; ?>

--- a/tests/php/Unit/TestPlugin.php
+++ b/tests/php/Unit/TestPlugin.php
@@ -84,7 +84,6 @@ class TestPlugin extends \WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertContains( 'It looks like Block Lab is active.', $output );
-		$this->assertContains( 'Deactivate', $output );
 	}
 
 	/**

--- a/tests/php/Unit/TestPlugin.php
+++ b/tests/php/Unit/TestPlugin.php
@@ -74,6 +74,20 @@ class TestPlugin extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test plugin_conflict_notice.
+	 *
+	 * @covers \Genesis\CustomBlocks\Plugin::plugin_conflict_notice
+	 */
+	public function test_plugin_conflict_notice() {
+		ob_start();
+		$this->instance->plugin_conflict_notice();
+		$output = ob_get_clean();
+
+		$this->assertContains( 'It looks like Block Lab is active.', $output );
+		$this->assertContains( 'Deactivate', $output );
+	}
+
+	/**
 	 * Test get_template_locations.
 	 *
 	 * This is also essentially the same test as in TestUtil.


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Checks if helper functions like `block_field()` are defined

#### Steps to Reproduce
1. Activate Block Lab 1.5.6 (current `develop` branch)
2. Activate this plugin's `develop` branch
3. Expected: it activates
4. Actual: There's an error from redeclaring `block_field()`

#### With this PR
There's a notice, and no PHP error:

![activating-gcb](https://user-images.githubusercontent.com/4063887/91901006-2d0e8600-ec65-11ea-913c-4de1b246092e.png)
