### PR TITLE
Prevent an error on activating when BL 1.5.6 is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Plugin released!
 * 13 fields to add
 * Simple templating, with PHP files
 
-## 1.0.1 - 2020-09-01 ###
+### 1.0.1 - 2020-09-01 ###
 
 Fix an error if Block Lab 1.5.6 is also active
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,10 @@ Plugin released!
 * Easily create custom blocks
 * 13 fields to add
 * Simple templating, with PHP files
+
+## 1.0.1 - 2020-09-01 ###
+
+Fix an error if Block Lab 1.5.6 is also active
+
+* Fixes an error with Block Lab 1.5.6, where it defines functions twice
+* Error does not occur with latest Block Lab

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "genesis-custom-blocks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-custom-blocks",
   "title": "Genesis Custom Blocks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Genesis Custom Blocks",
   "license": "GPL-2.0-or-later",

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -93,7 +93,13 @@ class Plugin extends PluginAbstract {
 	 * Requires helper functions.
 	 */
 	private function require_helpers() {
-		require_once __DIR__ . '/Helpers.php';
 		require_once __DIR__ . '/BlockApi.php';
+
+		if ( function_exists( 'block_field' ) || function_exists( 'block_row' ) ) {
+			return;
+		}
+
+		require_once __DIR__ . '/Helpers.php';
+
 	}
 }

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -95,7 +95,7 @@ class Plugin extends PluginAbstract {
 	private function require_helpers() {
 		require_once __DIR__ . '/BlockApi.php';
 
-		if ( function_exists( 'block_field' ) || function_exists( 'block_row' ) ) {
+		if ( function_exists( 'block_field' ) || function_exists( 'block_value' ) ) {
 			return;
 		}
 

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -66,6 +66,8 @@ class Plugin extends PluginAbstract {
 				$onboarding->plugin_activation();
 			}
 		);
+
+		$this->require_helpers();
 	}
 
 	/**
@@ -74,7 +76,6 @@ class Plugin extends PluginAbstract {
 	public function plugin_loaded() {
 		$this->admin = new Admin();
 		$this->register_component( $this->admin );
-		$this->require_helpers();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Loads helper functions when `genesis-custom-blocks.php` loads, so WP captures the fatal error and prevents downloading

#### Testing instructions
1. Go to `/wp-admin/plugins.php`
1. Activate BL 1.5.6: git checkout 902ae8a5f0493172ab6a2f269519854f4e47b207
1. Activate this plugin
1. Expected: this plugin activates as without an error:

![no-error-gcb-activation](https://user-images.githubusercontent.com/4063887/91910315-65699080-ec74-11ea-9dde-7f77de9b3e7e.png)

