### PR TITLE
Don't add assets to build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,18 +45,13 @@ gulp.task( 'bundle', function () {
 
 gulp.task( 'remove:bundle', function () {
 	return del( [
-		'package/assets/*',
 		'package/tags/*',
 		'package/trunk/*',
 	] );
 } );
 
 gulp.task( 'wporg:prepare', function () {
-	return run( 'mkdir -p package/assets package/trunk package/tags package/trunk/language' ).exec();
-} )
-
-gulp.task( 'wporg:assets', function () {
-	return run( 'mv package/prepare/assets/wporg/*.* package/assets' ).exec();
+	return run( 'mkdir -p package/trunk package/tags package/trunk/language' ).exec();
 } )
 
 gulp.task( 'wporg:readme', function ( cb ) {
@@ -81,7 +76,6 @@ gulp.task( 'wporg:trunk', function () {
 gulp.task( 'clean:bundle', function () {
 	return del( [
 		'package/trunk/package',
-		'package/trunk/assets/wporg',
 		'package/trunk/coverage',
 		'package/trunk/js/blocks',
 		'package/trunk/js/src',
@@ -124,7 +118,6 @@ gulp.task( 'default', gulp.series(
 	'run:build',
 	'bundle',
 	'wporg:prepare',
-	'wporg:assets',
 	'wporg:readme',
 	'wporg:trunk',
 	'version',


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Doesn't add the `assets/` directory
* There shouldn't usually be changes to assets

#### Testing instructions
