### PR TITLE
Add wp.org SVN automation, mainly copied from Genesis Blocks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
       - checkout
       - run:
           command: |
-            source $BASH_ENV
             sudo apt-get update && sudo apt-get install subversion
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - set-up-packages
       - run: npm run env start && npm run test:e2e
 
-  svn-deploy-tag:
+  svn-deploy:
     executor:
       name: php
     working_directory: ~/project/svn_deploy
@@ -120,7 +120,8 @@ jobs:
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp
             cd package
-            svn add trunk/* tags/$BUILD_VERSION/* assets/*
+            svn up trunk assets
+            svn up tags --depth=empty
             echo "Here is the stat"
             svn stat
 
@@ -138,5 +139,5 @@ workflows:
       - e2e-tests
   deploy:
     jobs:
-      - svn-deploy-tag:
+      - svn-deploy:
           context: genesis-svn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp
             cd package
-            SVN_DIRECTORIES="trunks tags assets"
+            SVN_DIRECTORIES="trunk tags assets"
             svn stat $SVN_DIRECTORIES | { grep -E '^\?' || true; } | awk '{print $2}' | xargs -r svn add
             svn stat $SVN_DIRECTORIES | { grep -E '^\!' || true; } | awk '{print $2}' | xargs -r svn rm
             svn up $SVN_DIRECTORIES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
             svn up $SVN_DIRECTORIES
             echo "Here is the svn stat about to be checked in:"
             svn stat
+            svn ci -m "Tagging ${BUILD_VERSION} from GitHub" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
 
 workflows:
   test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,13 +115,14 @@ jobs:
       - set-version
       - run:
           command: |
+            source $BASH_ENV
             sudo apt-get update && sudo apt-get install subversion
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp
             cd package
-            svn add trunk/* tags/* assets/* --force
+            svn add trunk/* tags/$BUILD_VERSION/* assets/*
+            echo "Here is the stat"
             svn stat
-            source $BASH_ENV
 
 workflows:
   lint-all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,19 @@ commands:
             ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
             [[ "$EXPECTED_SIGNATURE" == "$ACTUAL_SIGNATURE" ]] && sudo php composer-setup.php --install-dir=/bin --filename=composer || exit 1
 
+  svn-setup:
+    description: "Set up SVN"
+    steps:
+      - run:
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
+            npm ci && npm run gulp
+            cd package
+            svn up trunk
+            svn up tags
+            svn stat
+
 jobs:
   lint:
     executor:
@@ -99,6 +112,16 @@ jobs:
       - set-up-packages
       - run: npm run env start && npm run test:e2e
 
+  svn-deploy-tag:
+    executor:
+      name: php
+    working_directory: ~/project/svn_deploy
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - checkout
+      - svn-setup
+
 workflows:
   lint-all:
     jobs:
@@ -111,3 +134,12 @@ workflows:
               php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
       - js-tests
       - e2e-tests
+  deploy:
+    jobs:
+      - svn-deploy-tag:
+          context: genesis-svn
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+((?!built))$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ jobs:
             cd package
             svn up trunk tags assets
             svn stat | grep -E '^\?\s+((trunk)|(tags)|(assets))/' | cut -c8- | xargs svn add
-            svn stat | grep -E '^\!\s+((trunk)|(tags)|(assets))/' | cut -c8- | xargs svn rm
             echo "Here is the svn stat about to be checked in:"
             svn stat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,6 @@ commands:
             ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
             [[ "$EXPECTED_SIGNATURE" == "$ACTUAL_SIGNATURE" ]] && sudo php composer-setup.php --install-dir=/bin --filename=composer || exit 1
 
-  set-version:
-    description: "Set the VERSION environment variable"
-    steps:
-      - run: echo "export BUILD_VERSION=$(grep 'Version:' genesis-custom-blocks.php | cut -f4 -d' ')" >> ${BASH_ENV}
-
 jobs:
   lint:
     executor:
@@ -112,7 +107,6 @@ jobs:
       - attach_workspace:
           at: ~/project
       - checkout
-      - set-version
       - run:
           command: |
             source $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
       - checkout
       - run:
           command: |
+            BUILD_VERSION=$(grep 'Version:' genesis-custom-blocks.php | cut -f4 -d' ')
             sudo apt-get update && sudo apt-get install subversion
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,13 @@ commands:
             ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
             [[ "$EXPECTED_SIGNATURE" == "$ACTUAL_SIGNATURE" ]] && sudo php composer-setup.php --install-dir=/bin --filename=composer || exit 1
 
+  set-version:
+    description: "Set the VERSION environment variable"
+    steps:
+      - run: echo "export BUILD_VERSION=$(grep 'Version:' genesis-custom-blocks.php | cut -f4 -d' ')" >> ${BASH_ENV}
+
   svn-setup:
-    description: "Set up SVN"
+    description: "Set up SVN and check in the plugin"
     steps:
       - run:
           command: |
@@ -40,6 +45,7 @@ commands:
             svn up trunk
             svn up tags
             svn stat
+            source $BASH_ENV
 
 jobs:
   lint:
@@ -120,6 +126,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - checkout
+      - set-version
       - svn-setup
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,19 +33,6 @@ commands:
     steps:
       - run: echo "export BUILD_VERSION=$(grep 'Version:' genesis-custom-blocks.php | cut -f4 -d' ')" >> ${BASH_ENV}
 
-  svn-setup:
-    description: "Set up SVN and check in the plugin"
-    steps:
-      - run:
-          command: |
-            sudo apt-get update && sudo apt-get install subversion
-            svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
-            npm ci && npm run gulp
-            cd package
-            svn add trunk/* tags/* assets/* --force
-            svn stat
-            source $BASH_ENV
-
 jobs:
   lint:
     executor:
@@ -126,7 +113,15 @@ jobs:
           at: ~/project
       - checkout
       - set-version
-      - svn-setup
+      - run:
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
+            npm ci && npm run gulp
+            cd package
+            svn add trunk/* tags/* assets/* --force
+            svn stat
+            source $BASH_ENV
 
 workflows:
   lint-all:
@@ -144,8 +139,3 @@ workflows:
     jobs:
       - svn-deploy-tag:
           context: genesis-svn
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+((?!built))$/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,10 +122,7 @@ jobs:
             svn stat
 
 workflows:
-  lint-all:
-    jobs:
-      - lint
-  tests:
+  test-deploy:
     jobs:
       - php-tests:
           matrix:
@@ -133,10 +130,12 @@ workflows:
               php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
       - js-tests
       - e2e-tests
-  deploy:
-    jobs:
+      - lint
       - svn-deploy:
           context: genesis-svn
+          requires:
+            - php-tests
+            - lint
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,9 +120,10 @@ jobs:
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp
             cd package
-            svn up trunk assets
-            svn up tags --depth=empty
-            echo "Here is the stat"
+            svn up trunk tags assets
+            svn stat | grep -E '^\?\s+((trunk)|(tags)|(assets))/' | cut -c8- | xargs svn add
+            svn stat | grep -E '^\!\s+((trunk)|(tags)|(assets))/' | cut -c8- | xargs svn rm
+            echo "Here is the svn stat about to be checked in:"
             svn stat
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,10 @@ jobs:
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp
             cd package
-            svn up trunk tags assets
-            svn stat | grep -E '^\?\s+((trunk)|(tags)|(assets))/' | cut -c8- | xargs svn add
+            SVN_DIRECTORIES="trunks tags assets"
+            svn stat $SVN_DIRECTORIES | { grep -E '^\?' || true; } | awk '{print $2}' | xargs -r svn add
+            svn stat $SVN_DIRECTORIES | { grep -E '^\!' || true; } | awk '{print $2}' | xargs -r svn rm
+            svn up $SVN_DIRECTORIES
             echo "Here is the svn stat about to be checked in:"
             svn stat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,3 +141,8 @@ workflows:
     jobs:
       - svn-deploy:
           context: genesis-svn
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,7 @@ commands:
             svn co https://plugins.svn.wordpress.org/genesis-custom-blocks package
             npm ci && npm run gulp
             cd package
-            svn up trunk
-            svn up tags
+            svn add trunk/* tags/* assets/* --force
             svn stat
             source $BASH_ENV
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,14 @@ The plugin versions should follow [Semantic Versioning](https://semver.org/#sema
 1. [Create a release](https://github.com/studiopress/genesis-custom-blocks/releases/new), targeting whatever branch you chose in step 1.
 1. Upload the `.zip` file you created to the release page.
 1. The 'Tag version' should be the plugin version, like `1.0.0`.
-1. There will be a `package/trunk/` directory from running `gulp` earlier, along with a tag directory `/package/x.x.x/`, with `x.x.x` being the version number.
-1. Commit both of those directories to the wp.org SVN repo.
-1. Do `./bin/tag-built.sh`
-1. This will create a built tag of the plugin and push it. Then, other plugins or entire sites can require the plugin as a Composer dependency.
+1. Publish the release
+1. [CircleCI](https://github.com/studiopress/genesis-custom-blocks/blob/develop/.circleci/config.yml) will then deploy the plugin to the wp.org SVN
+1. Smoke test the plugin [deployed to wp.org](https://wordpress.org/plugins/genesis-custom-blocks/)
 1. If this release was for a release branch, like `1.0`, open a PR from that branch to `develop`.
+1. Do `./bin/tag-built.sh`
+1. This will create a built tag like `1.0.0-built` and push it. Then, other plugins like the Pro plugin can require this plugin as a Composer dependency.
+1. In the Pro plugin's `composer.json`, [update](https://github.com/studiopress/genesis-custom-blocks-pro/blob/develop/CONTRIBUTING.md#plugin-dependency) the commit hash of this free plugin to the new built tag.
+1. Also [create a release](https://github.com/studiopress/genesis-custom-blocks-pro/blob/develop/CONTRIBUTING.md#release-procedure) of the Pro plugin, as it should have the latest version of this free plugin.
 1. To resume normal local development, do `composer install`, as running `gulp` will remove the Composer dev dependencies.
 
 Thanks! :heart: :heart: :heart:

--- a/bin/tag-built.sh
+++ b/bin/tag-built.sh
@@ -3,7 +3,8 @@
 
 set -e
 
-gulp
+npm ci
+npm run gulp
 tag=$(grep 'Version:' package/trunk/genesis-custom-blocks.php | sed 's/.*: //' | sed 's/-[0-9]\{8\}T[0-9]\{6\}Z-[a-f0-9]*$//')
 if [[ -z "$tag" ]]; then
     echo "Error: Unable to determine tag."
@@ -16,6 +17,7 @@ if git rev-parse "$built_tag" >/dev/null 2>&1; then
     exit 2
 fi
 
+git fetch origin --tags
 git checkout "$tag"
 mkdir built
 git clone . built/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,13 +45,18 @@ gulp.task( 'bundle', function () {
 
 gulp.task( 'remove:bundle', function () {
 	return del( [
+		'package/assets/*',
 		'package/tags/*',
 		'package/trunk/*',
 	] );
 } );
 
 gulp.task( 'wporg:prepare', function () {
-	return run( 'mkdir -p package/trunk package/tags package/trunk/language' ).exec();
+	return run( 'mkdir -p package/assets package/trunk package/tags package/trunk/language' ).exec();
+} )
+
+gulp.task( 'wporg:assets', function () {
+	return run( 'mv package/prepare/assets/wporg/*.* package/assets' ).exec();
 } )
 
 gulp.task( 'wporg:readme', function ( cb ) {
@@ -76,6 +81,7 @@ gulp.task( 'wporg:trunk', function () {
 gulp.task( 'clean:bundle', function () {
 	return del( [
 		'package/trunk/package',
+		'package/trunk/assets/wporg',
 		'package/trunk/coverage',
 		'package/trunk/js/blocks',
 		'package/trunk/js/src',
@@ -118,6 +124,7 @@ gulp.task( 'default', gulp.series(
 	'run:build',
 	'bundle',
 	'wporg:prepare',
+	'wporg:assets',
 	'wporg:readme',
 	'wporg:trunk',
 	'version',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,32 +1,30 @@
-var gulp = require( 'gulp' );
-var merge = require('merge-stream');
-var del = require( 'del' );
-var run = require( 'gulp-run' );
-var replace = require( 'gulp-string-replace' );
+const gulp = require( 'gulp' );
+const del = require( 'del' );
+const run = require( 'gulp-run' );
 
-var fs = require( 'fs' );
-var config = JSON.parse( fs.readFileSync( './package.json' ) );
+const fs = require( 'fs' );
+const config = JSON.parse( fs.readFileSync( './package.json' ).toString() );
 
 gulp.task( 'verify:versions', function () {
 	return run( 'php bin/verify-versions.php' ).exec();
-} )
+} );
 
-gulp.task( 'version', function () {
-	var pluginStream = gulp.src( [ 'genesis-custom-blocks.php' ] )
-		.pipe( replace( new RegExp( /Version:\s*(.*)/, 'g' ), "Version: " + config.version ) )
-		.pipe(gulp.dest('./package/trunk/'))
-		.pipe(gulp.dest('./'))
+gulp.task( 'remove:bundle', function () {
+	return del( [
+		'package/assets/*',
+		'package/trunk/*',
+	] );
+} );
 
-	return pluginStream;
-} )
 
 gulp.task( 'install:dependencies', function () {
 	return run( 'composer install -o --no-dev' ).exec();
-} )
+} );
+
 
 gulp.task( 'run:build', function () {
 	return run( 'npm run build' ).exec();
-} )
+} );
 
 gulp.task( 'bundle', function () {
 	return gulp.src( [
@@ -43,39 +41,31 @@ gulp.task( 'bundle', function () {
 	.pipe( gulp.dest( 'package/prepare' ) );
 } );
 
-gulp.task( 'remove:bundle', function () {
-	return del( [
-		'package/assets/*',
-		'package/trunk/*',
-	] );
-} );
-
 gulp.task( 'wporg:prepare', function () {
 	return run( 'mkdir -p package/assets package/trunk package/tags package/trunk/language' ).exec();
-} )
+} );
 
 gulp.task( 'wporg:assets', function () {
 	return run( 'mv package/prepare/assets/wporg/*.* package/assets' ).exec();
-} )
+} );
 
 gulp.task( 'wporg:readme', function ( cb ) {
-	var changelog = fs.readFileSync( './CHANGELOG.md' ).toString();
+	const changelog = fs.readFileSync( './CHANGELOG.md' ).toString();
 
-	var readme = fs.readFileSync( './README.md' )
+	const readme = fs.readFileSync( './README.md' )
 		.toString()
 		.concat( '\n' + changelog )
-		.replace( new RegExp( /Stable tag:\s*(.*)/, 'g' ), "Stable tag: " + config.version )
 		.replace( new RegExp( '###', 'g'), '=' )
 		.replace( new RegExp( '##', 'g'), '==' )
 		.replace( new RegExp( '#', 'g'), '===' )
 		.replace( new RegExp( '__', 'g'), '*' );
 
 	return fs.writeFile( 'package/trunk/readme.txt', readme, cb );
-} )
+} );
 
 gulp.task( 'wporg:trunk', function () {
 	return run( 'mv package/prepare/* package/trunk' ).exec();
-} )
+} );
 
 gulp.task( 'clean:bundle', function () {
 	return del( [
@@ -109,12 +99,12 @@ gulp.task( 'clean:bundle', function () {
 } );
 
 gulp.task( 'copy:tag', function () {
-	return run( 'export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); mkdir -p package/tags/$BUILD_VERSION/; cp -r package/trunk/* package/tags/$BUILD_VERSION/' ).exec();
-} )
+	return run( 'export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); [ -z "$BUILD_VERSION" ] && exit 1; mkdir -p package/tags/$BUILD_VERSION/; rm -rf package/tags/$BUILD_VERSION/*; cp -r package/trunk/* package/tags/$BUILD_VERSION/' ).exec();
+} );
 
 gulp.task( 'create:zip', function () {
 	return run( 'cp -r package/trunk package/genesis-custom-blocks; export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); cd package; pwd; zip -r genesis-custom-blocks.$BUILD_VERSION.zip genesis-custom-blocks/; echo "ZIP of build: $(pwd)/genesis-custom-blocks.$BUILD_VERSION.zip"; rm -rf genesis-custom-blocks' ).exec();
-} )
+} );
 
 gulp.task( 'default', gulp.series(
 	'verify:versions',
@@ -126,7 +116,6 @@ gulp.task( 'default', gulp.series(
 	'wporg:assets',
 	'wporg:readme',
 	'wporg:trunk',
-	'version',
 	'clean:bundle',
 	'copy:tag',
 	'create:zip'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,7 +109,7 @@ gulp.task( 'clean:bundle', function () {
 } );
 
 gulp.task( 'copy:tag', function () {
-	return run( 'export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); cp -r package/trunk package/tags/$BUILD_VERSION' ).exec();
+	return run( 'export BUILD_VERSION=$(grep "Version" genesis-custom-blocks.php | cut -f4 -d" "); mkdir -p package/tags/$BUILD_VERSION/; cp -r package/trunk/* package/tags/$BUILD_VERSION/' ).exec();
 } )
 
 gulp.task( 'create:zip', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,6 @@ gulp.task( 'bundle', function () {
 gulp.task( 'remove:bundle', function () {
 	return del( [
 		'package/assets/*',
-		'package/tags/*',
 		'package/trunk/*',
 	] );
 } );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,18 +45,13 @@ gulp.task( 'bundle', function () {
 
 gulp.task( 'remove:bundle', function () {
 	return del( [
-		'package/assets/*',
 		'package/tags/*',
 		'package/trunk/*',
 	] );
 } );
 
 gulp.task( 'wporg:prepare', function () {
-	return run( 'mkdir -p package/assets package/trunk package/tags package/trunk/language' ).exec();
-} )
-
-gulp.task( 'wporg:assets', function () {
-	return run( 'mv package/prepare/assets/wporg/*.* package/assets' ).exec();
+	return run( 'mkdir -p package/trunk package/tags package/trunk/language' ).exec();
 } )
 
 gulp.task( 'wporg:readme', function ( cb ) {
@@ -81,7 +76,6 @@ gulp.task( 'wporg:trunk', function () {
 gulp.task( 'clean:bundle', function () {
 	return del( [
 		'package/trunk/package',
-		'package/trunk/assets/wporg',
 		'package/trunk/coverage',
 		'package/trunk/js/blocks',
 		'package/trunk/js/src',
@@ -124,7 +118,6 @@ gulp.task( 'default', gulp.series(
 	'run:build',
 	'bundle',
 	'wporg:prepare',
-	'wporg:assets',
 	'wporg:readme',
 	'wporg:trunk',
 	'version',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,7 @@
-const gulp = require( 'gulp' );
 const del = require( 'del' );
-const run = require( 'gulp-run' );
-
 const fs = require( 'fs' );
-const config = JSON.parse( fs.readFileSync( './package.json' ).toString() );
+const gulp = require( 'gulp' );
+const run = require( 'gulp-run' );
 
 gulp.task( 'verify:versions', function () {
 	return run( 'php bin/verify-versions.php' ).exec();
@@ -15,7 +13,6 @@ gulp.task( 'remove:bundle', function () {
 		'package/trunk/*',
 	] );
 } );
-
 
 gulp.task( 'install:dependencies', function () {
 	return run( 'composer install -o --no-dev' ).exec();


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Adds a wp.org SVN deployment step, thanks to [Genesis Blocks](https://github.com/studiopress/genesis-blocks/blob/37c4a96a8c8563bb0df62959afbeb33f364c279f/.circleci/config.yml#L43)
* On creating a tag like `1.0.2`, this deploys to wp.org
* It won't deploy for tags like [1.0.1-built](https://github.com/studiopress/genesis-custom-blocks/releases/tag/1.0.1-built), which is a tag for Composer or git submodule use

#### Testing instructions
1. `npm ci && npm run gulp`
1. Upload and activate `package/genesis-custom-blocks.1.0.1.zip` to another WP instance
1. Expected: it activates without error, and the submenus are there, like 'All Blocks', 'Add New', 'Settings', and 'Genesis Pro'
1. `circleci local execute --job svn-deploy`
1. Expected: the stat that is shown at the end is something like:
<details>
<summary>Expected stat</summary>

```
Here is the svn stat about to be checked in:
?       genesis-custom-blocks.1.0.1.zip
M       tags/1.0.1/vendor/autoload.php
M       tags/1.0.1/vendor/composer/autoload_real.php
M       tags/1.0.1/vendor/composer/autoload_static.php
M       trunk/vendor/autoload.php
M       trunk/vendor/composer/autoload_real.php
M       trunk/vendor/composer/autoload_static.php
Success!
```
</details>

6. Simulate a new version:
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index f97d468..c060ff9 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ Fix an error if Block Lab 1.5.6 is also active
 
 * Fixes an error with Block Lab 1.5.6, where it defines functions twice
 * Error does not occur with latest Block Lab
+
+### 1.0.2 - 2020-09-13 ###
+
+Fix a bug
diff --git a/README.md b/README.md
index 1aacc92..b6b8bcd 100644
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 
diff --git a/genesis-custom-blocks.php b/genesis-custom-blocks.php
index c10c48a..6467cda 100644
--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2
diff --git a/package.json b/package.json
index 3ed2035..0b5615d 100644
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-custom-blocks",
   "title": "Genesis Custom Blocks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Genesis Custom Blocks",
   "license": "GPL-2.0-or-later",
```
7. `circleci local execute --job svn-deploy`

8. Expected: the stat that the job shows at the end is something like:
<details>
<summary>Expected stat</summary>

```
Here is the svn stat about to be checked in:
?       genesis-custom-blocks.1.0.2.zip
A       tags/1.0.2
A       tags/1.0.2/LICENSE
A       tags/1.0.2/assets
A       tags/1.0.2/assets/icons.json
A       tags/1.0.2/assets/images
A       tags/1.0.2/assets/images/admin-menu-icon.svg
A       tags/1.0.2/assets/images/logo-reversed.svg
A       tags/1.0.2/css
A       tags/1.0.2/css/admin.block-edit.css
A       tags/1.0.2/css/admin.block-post.css
A       tags/1.0.2/css/admin.css
A       tags/1.0.2/css/admin.onboarding.css
A       tags/1.0.2/css/admin.upgrade.css
A       tags/1.0.2/css/blocks.editor.asset.php
A       tags/1.0.2/css/blocks.editor.css
A       tags/1.0.2/genesis-custom-blocks.php
A       tags/1.0.2/js
A       tags/1.0.2/js/admin.block-post.js
A       tags/1.0.2/js/editor.blocks.asset.php
A       tags/1.0.2/js/editor.blocks.js
A       tags/1.0.2/language
A       tags/1.0.2/php
A       tags/1.0.2/php/Admin
A       tags/1.0.2/php/Admin/Admin.php
A       tags/1.0.2/php/Admin/Documentation.php
A       tags/1.0.2/php/Admin/Import.php
A       tags/1.0.2/php/Admin/Onboarding.php
A       tags/1.0.2/php/Admin/Upgrade.php
A       tags/1.0.2/php/BlockApi.php
A       tags/1.0.2/php/Blocks
A       tags/1.0.2/php/Blocks/Block.php
A       tags/1.0.2/php/Blocks/Controls
A       tags/1.0.2/php/Blocks/Controls/Checkbox.php
A       tags/1.0.2/php/Blocks/Controls/Color.php
A       tags/1.0.2/php/Blocks/Controls/ControlAbstract.php
A       tags/1.0.2/php/Blocks/Controls/ControlSetting.php
A       tags/1.0.2/php/Blocks/Controls/Email.php
A       tags/1.0.2/php/Blocks/Controls/Image.php
A       tags/1.0.2/php/Blocks/Controls/Multiselect.php
A       tags/1.0.2/php/Blocks/Controls/Number.php
A       tags/1.0.2/php/Blocks/Controls/Radio.php
A       tags/1.0.2/php/Blocks/Controls/Range.php
A       tags/1.0.2/php/Blocks/Controls/Select.php
A       tags/1.0.2/php/Blocks/Controls/Text.php
A       tags/1.0.2/php/Blocks/Controls/Textarea.php
A       tags/1.0.2/php/Blocks/Controls/Toggle.php
A       tags/1.0.2/php/Blocks/Controls/Url.php
A       tags/1.0.2/php/Blocks/Field.php
A       tags/1.0.2/php/Blocks/Loader.php
A       tags/1.0.2/php/ComponentAbstract.php
A       tags/1.0.2/php/ComponentInterface.php
A       tags/1.0.2/php/Deprecated.php
A       tags/1.0.2/php/Helpers.php
A       tags/1.0.2/php/Plugin.php
A       tags/1.0.2/php/PluginAbstract.php
A       tags/1.0.2/php/PluginInterface.php
A       tags/1.0.2/php/PostTypes
A       tags/1.0.2/php/PostTypes/BlockPost.php
A       tags/1.0.2/php/Util.php
A       tags/1.0.2/php/Views
A       tags/1.0.2/php/Views/Upgrade.php
A       tags/1.0.2/readme.txt
A       tags/1.0.2/vendor
A       tags/1.0.2/vendor/autoload.php
A       tags/1.0.2/vendor/composer
A       tags/1.0.2/vendor/composer/ClassLoader.php
A       tags/1.0.2/vendor/composer/LICENSE
A       tags/1.0.2/vendor/composer/autoload_classmap.php
A       tags/1.0.2/vendor/composer/autoload_namespaces.php
A       tags/1.0.2/vendor/composer/autoload_psr4.php
A       tags/1.0.2/vendor/composer/autoload_real.php
A       tags/1.0.2/vendor/composer/autoload_static.php
A       tags/1.0.2/vendor/composer/installed.json
M       trunk/genesis-custom-blocks.php
M       trunk/readme.txt
M       trunk/vendor/autoload.php
M       trunk/vendor/composer/autoload_real.php
M       trunk/vendor/composer/autoload_static.php
Success!
```

</details>

9. `touch php/Foo.php && rm php/Plugin.php`
10. `git add php/Foo.php php/Plugin.php && git commit --no-verify -m "Will revert: test adding and deleting a file"`
11. `circleci local execute --job svn-deploy`
12. Expected: the stat is something like:
<details>
<summary>Expected stat</summary>

```
Here is the svn stat about to be checked in:
?       genesis-custom-blocks.1.0.1.zip
A       tags/1.0.1/php/Foo.php
D       tags/1.0.1/php/Plugin.php
M       tags/1.0.1/vendor/autoload.php
M       tags/1.0.1/vendor/composer/autoload_classmap.php
M       tags/1.0.1/vendor/composer/autoload_real.php
M       tags/1.0.1/vendor/composer/autoload_static.php
A       trunk/php/Foo.php
D       trunk/php/Plugin.php
M       trunk/vendor/autoload.php
M       trunk/vendor/composer/autoload_classmap.php
M       trunk/vendor/composer/autoload_real.php
M       trunk/vendor/composer/autoload_static.php
Success!
```
</details>

13. We normally won't be deploying without bumping the version, but that tests that files were deleted and added as expected.
