### PR TITLE
Change the type of the Textarea field

### DIFF
--- a/php/Blocks/Controls/Textarea.php
+++ b/php/Blocks/Controls/Textarea.php
@@ -22,11 +22,11 @@ class Textarea extends ControlAbstract {
 	public $name = 'textarea';
 
 	/**
-	 * Control type.
+	 * Field variable type.
 	 *
 	 * @var string
 	 */
-	public $type = 'textarea';
+	public $type = 'string';
 
 	/**
 	 * Textarea constructor.

--- a/php/Blocks/Field.php
+++ b/php/Blocks/Field.php
@@ -152,17 +152,6 @@ class Field {
 			case 'string':
 				$value = strval( $value );
 				break;
-			case 'textarea':
-				$value = strval( $value );
-				if ( isset( $this->settings['new_lines'] ) ) {
-					if ( 'autop' === $this->settings['new_lines'] ) {
-						$value = wpautop( $value );
-					}
-					if ( 'autobr' === $this->settings['new_lines'] ) {
-						$value = nl2br( $value );
-					}
-				}
-				break;
 			case 'boolean':
 				if ( 1 === $value ) {
 					$value = true;
@@ -178,6 +167,18 @@ class Field {
 					$value = (array) $value;
 				}
 				break;
+		}
+
+		if ( 'textarea' === $this->control ) {
+			$value = strval( $value );
+			if ( isset( $this->settings['new_lines'] ) ) {
+				if ( 'autop' === $this->settings['new_lines'] ) {
+					$value = wpautop( $value );
+				}
+				if ( 'autobr' === $this->settings['new_lines'] ) {
+					$value = nl2br( $value );
+				}
+			}
 		}
 
 		return $value;

--- a/tests/php/Unit/Blocks/TestField.php
+++ b/tests/php/Unit/Blocks/TestField.php
@@ -116,4 +116,61 @@ class TestField extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'settings', $config );
 		$this->assertEquals( 'Custom Setting', $config['custom'] );
 	}
+
+	/**
+	 * Test cast_value on a textarea field with no autop.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Field::cast_value()
+	 */
+	public function test_cast_value_textarea_no_autop() {
+		$field         = new Field(
+			[
+				'type'    => 'text',
+				'control' => 'textarea',
+			]
+		);
+		$initial_value = "\n\n Here is some text \n\n This is more";
+
+		$this->assertEquals( $initial_value, $field->cast_value( $initial_value ) );
+	}
+
+	/**
+	 * Test cast_value on a textarea field with autop.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Field::cast_value()
+	 */
+	public function test_cast_value_textarea_with_autop() {
+		$field = new Field(
+			[
+				'type'     => 'text',
+				'control'  => 'textarea',
+				'settings' => [ 'new_lines' => 'autop' ],
+			]
+		);
+
+		$this->assertEquals(
+			"<p>Here is some text<br />\n This is more</p>\n",
+			$field->cast_value( "Here is some text \n This is more" )
+		);
+	}
+
+	/**
+	 * Test cast_value on a textarea field with autobr.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Field::cast_value()
+	 */
+	public function test_cast_value_textarea_with_autbr() {
+		$field = new Field(
+			[
+				'type'     => 'text',
+				'control'  => 'textarea',
+				'settings' => [ 'new_lines' => 'autobr' ],
+			]
+		);
+
+		$this->assertEquals(
+			"Here is some text <br />\n This is more <br />\n Here is another one",
+			$field->cast_value( "Here is some text \n This is more \n Here is another one" )
+		);
+	}
 }

--- a/tests/php/Unit/Blocks/TestField.php
+++ b/tests/php/Unit/Blocks/TestField.php
@@ -159,7 +159,7 @@ class TestField extends \WP_UnitTestCase {
 	 *
 	 * @covers \Genesis\CustomBlocks\Blocks\Field::cast_value()
 	 */
-	public function test_cast_value_textarea_with_autbr() {
+	public function test_cast_value_textarea_with_autobr() {
 		$field = new Field(
 			[
 				'type'     => 'text',


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Changes the Textarea field `->type` from `textarea` to `string`
* The `->type` is for the data type of attribute that the block should accept, not for the control type like 'textarea' or 'multiselect'
* Fixes https://wordpress.org/support/topic/the-rest_validate_value_from_schema-function-was-called-incorrectly-2/

#### Steps to reproduce
1. Create a new block with a Textarea field
1. Publish it
1. Add it to the block editor
1. Expected: there's no notice
1. Actual: this notice shows for about a second, then disappears:

![notice-here](https://user-images.githubusercontent.com/4063887/92513156-787ce300-f1d5-11ea-83b5-a2444c272347.png)

#### Testing instructions for this PR
1. Create a new block with 3 Textarea fields
1. For the first Textarea, set New Lines > Automatically add paragraphs
1. For the second, set New Lines > Automatically add linebreaks
1. For the third, set New Lines > No formatting
1. Publish it
1. Add it to the block editor
1. Expected: there's no PHP notice anymore
1. Expected: the linebreak and newline behavior is the same as before