### PR TITLE
Replace a hash with PR, fixing typo in readme.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,4 @@ Fix an error if Block Lab 1.5.6 is also active
 
 Fix a notice from the Textarea field
 
-* Fixes a notice from the Textarea field having the wrong type. [#33](https://github.com/studiopress/genesis-custom-blocks/pull/33)
+* Fixes a notice from the Textarea field having the wrong type. [PR 33](https://github.com/studiopress/genesis-custom-blocks/pull/33)


### PR DESCRIPTION

<!--- Please summarize this PR in the title above -->

#### Background
`npm run gulp` turned `#33` into `===33`:
https://github.com/studiopress/genesis-custom-blocks/blob/469f0098eb97774b6a821ddf2dd9fcb2f8f69cff/readme.txt#L121

#### Changes
* Prevents this from happening by simply using `PR 33`. 
* Maybe use a more elegant solution later on 
#### Testing instructions
 * Just a sanity check would be great, no other testing needed