### PR TITLE
Address failed PHPUnit test

### DIFF
--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -596,7 +596,7 @@ class Loader extends ComponentAbstract {
 	 * @return array The filtered endpoints, with the GCB endpoints allowing POST requests.
 	 */
 	public function add_rest_method( $endpoints ) {
-		if ( is_wp_version_compatible( '5.6' ) ) {
+		if ( is_wp_version_compatible( '5.5' ) ) {
 			return $endpoints;
 		}
 

--- a/tests/php/Unit/Blocks/TestLoader.php
+++ b/tests/php/Unit/Blocks/TestLoader.php
@@ -65,7 +65,7 @@ class TestLoader extends AbstractTemplate {
 	 *
 	 * @var string
 	 */
-	private $wp_version_with_correct_endpoint = '5.6';
+	private $wp_version_with_correct_endpoint = '5.5';
 
 	/**
 	 * Tear down after each test.
@@ -500,7 +500,7 @@ class TestLoader extends AbstractTemplate {
 		];
 
 		if ( is_wp_version_compatible( $this->wp_version_with_correct_endpoint ) ) {
-			$initial_routes[ $gcb_block_route ]['methods'] = $expected_methods;
+			$initial_routes[ $gcb_block_route ][0]['methods'] = $expected_methods;
 		}
 
 		$actual = $this->instance->add_rest_method( $initial_routes );


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Corrects the WP version in which to not filter to 5.5 (originally in https://github.com/studiopress/genesis-custom-blocks/pull/39)
* WP 5.5+ has GET and POST methods for the <ServerSideRender> endpoint, via this [Core patch](https://core.trac.wordpress.org/ticket/49680). So this doesn't need to filter in 5.5+
* It probably wasn't that bad that it filtered it, just needless.
* Todo: when this is merged, [open a PR](https://github.com/studiopress/genesis-custom-blocks/compare/feature/react-ui...develop) from `develop` to `feature/react-ui`

#### Testing instructions
* Please test with the steps to reproduce in [BHH-569](https://wpengine.atlassian.net/browse/BH-569?focusedCommentId=318658)