### PR TITLE
Bump 'Tested up to' to 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.0
-Tested up to: 5.5
+Tested up to: 5.6
 Requires PHP: 5.6
 Stable tag: 1.0.3
 License: GPLv2 or later


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Bumps 'Tested up to' from `5.5` to `5.6`
* That should cover us for all point versions of `5.6` like `5.6.1`, until `5.7` is released

#### Testing instructions
None needed, unless you'd like to do similar testing that I did ([gif screencasts](https://wpengine.atlassian.net/browse/GF-2498?focusedCommentId=347046))

1. `wp core update --version=5.6-RC2`
1. Added a block for each one of the 13 free fields
1. The `<Edit>` for all of them look good
1. The `<ServerSideRender>` for all of them look good
1. Created a new block with all 13 of the free fields, to test that jQuery migrate doesn’t cause a problem (that UI uses jQuery)
1. That worked fine: 
<img width="1187" alt="new-block-all-fields" src="https://user-images.githubusercontent.com/4063887/100938905-16bdd380-34bb-11eb-930f-b2c77d99efbf.png">
