### PR TITLE
Bump lodash to 4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16363,9 +16363,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "hpq": {
@@ -19874,9 +19874,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -28206,9 +28206,9 @@
           "dev": true
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -29326,8 +29326,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ignore-emit-webpack-plugin": "2.0.2",
     "jest-axe": "3.5.0",
     "jest-silent-reporter": "0.2.1",
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "merge-stream": "2.0.0",
     "mini-css-extract-plugin": "1.3.3",
     "node-sass": "4.14.1",


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Security fix: bump `lodash` from [dependabot alert](https://github.com/studiopress/genesis-custom-blocks/security/dependabot/package.json/lodash/open) 
* From doing `npm audit fix`
* It'd still be good to bump most of the packages versions in `package.json`, but that's a bigger scope

#### Testing instructions
* Not needed