### PR TITLE
[Not for merging] Add a simple WP-CLI file to query for the blocks and get their counts

### DIFF
--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -17,14 +17,15 @@ use Genesis\CustomBlocks\Blocks\Block;
  * @return array[] An array of associative arrays, with keys of 'field' and 'count'.
  */
 function get_fields() {
-	$field_histogram = [];
-	$block_query     = new WP_Query(
+	$block_query = new WP_Query(
 		[
 			'post_type'      => 'genesis_custom_block',
 			'post_status'    => 'publish',
 			'posts_per_page' => 100,
 		]
 	);
+
+	$field_histogram = [];
 	foreach ( $block_query->posts as $post ) {
 		$block = new Block( $post->ID );
 		foreach ( $block->fields as $field ) {

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -78,11 +78,4 @@ if ( ! defined( 'WP_CLI' ) ) {
 	exit( 1 );
 }
 
-if (
-	! is_plugin_active( 'genesis-custom-blocks/genesis-custom-blocks.php' )
-	&& ! is_plugin_active( 'genesis-custom-blocks-pro/genesis-custom-blocks-pro.php' )
-) {
-	echo "Genesis Custom Blocks is not active\n";
-}
-
 query_blocks();

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -2,7 +2,6 @@
 /**
  * Queries for the blocks on the site.
  *
- * phpcs:ignoreFile
  * @package Genesis\CustomBlocks
  */
 
@@ -19,10 +18,16 @@ use Genesis\CustomBlocks\Blocks\Block;
  */
 function get_fields() {
 	$field_histogram = [];
-	$block_query     = new WP_Query( [ 'post_type' =>'genesis_custom_block' ] );
-	foreach( $block_query->posts as $post ) {
+	$block_query     = new WP_Query(
+		[
+			'post_type'      => 'genesis_custom_block',
+			'post_status'    => 'publish',
+			'posts_per_page' => 100,
+		]
+	);
+	foreach ( $block_query->posts as $post ) {
 		$block = new Block( $post->ID );
-		foreach( $block->fields as $field ) {
+		foreach ( $block->fields as $field ) {
 			$field_histogram[ $field->control ] = ! empty( $field_histogram[ $field->control ] ) && is_int( $field_histogram[ $field->control ] )
 				? $field_histogram[ $field->control ] + 1
 				: 1;
@@ -57,7 +62,7 @@ function query_blocks() {
 }
 
 if ( ! defined( 'WP_CLI' ) ) {
- 	echo "Please run this with WP-CLI: wp eval-file bin/query-blocks.php\n";
+	echo "Please run this with WP-CLI: wp eval-file bin/query-blocks.php\n";
 	exit( 1 );
 }
 

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -66,6 +66,7 @@ function query_blocks() {
 		'format' => 'table',
 	];
 
+	WP_CLI::log( 'Total counts of each field type (control):' );
 	$formatter = new WP_CLI\Formatter( $assoc_args, $table_fields );
 	$formatter->display_items( $table_values );
 }
@@ -73,6 +74,13 @@ function query_blocks() {
 if ( ! defined( 'WP_CLI' ) ) {
 	echo "Please run this with WP-CLI: wp eval-file bin/query-blocks.php\n";
 	exit( 1 );
+}
+
+if (
+	! is_plugin_active( 'genesis-custom-blocks/genesis-custom-blocks.php' )
+	&& ! is_plugin_active( 'genesis-custom-blocks-pro/genesis-custom-blocks-pro.php' )
+) {
+	echo "Genesis Custom Blocks is not active\n";
 }
 
 query_blocks();

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -21,7 +21,7 @@ function get_fields() {
 		[
 			'post_type'      => 'genesis_custom_block',
 			'post_status'    => 'publish',
-			'posts_per_page' => 100,
+			'posts_per_page' => 99,
 		]
 	);
 

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -13,7 +13,12 @@ use WP_Query;
 /**
  * Gets the field types (controls) and their counts.
  *
- * @return array[] An array of associative arrays, with keys of 'field' and 'count'.
+ * @return array[] $fields {
+ *     The fields in all of the blocks.
+
+ *     @type string $field The type (control) of the field, like 'text'.
+ *     @type int    $count The count of that type in all of the blocks.
+ * }
  */
 function get_fields() {
 	$block_query = new WP_Query(

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -32,11 +32,12 @@ function get_fields() {
 	$field_histogram = [];
 	foreach ( $block_query->posts as $post ) {
 		$block_json = json_decode( $post->post_content, true );
-		if ( ! isset( $block_json[ 'genesis-custom-blocks/' . $post->post_name ]['fields'] ) ) {
+		$fields     = $block_json[ 'genesis-custom-blocks/' . $post->post_name ]['fields'];
+		if ( empty( $fields ) ) {
 			break;
 		}
 
-		foreach ( $block_json[ 'genesis-custom-blocks/' . $post->post_name ]['fields'] as $field_name => $field ) {
+		foreach ( $fields as $field_name => $field ) {
 			$field_histogram[ $field['control'] ] = ! empty( $field_histogram[ $field['control'] ] ) && is_int( $field_histogram[ $field['control'] ] )
 				? $field_histogram[ $field['control'] ] + 1
 				: 1;
@@ -64,13 +65,12 @@ function query_blocks() {
 	WP_CLI::log( sprintf( 'There are %1$d GCB blocks', $post_count->publish ) );
 	WP_CLI::log( "\n" );
 
-	$table_values = get_fields();
 	$table_fields = [ 'field', 'count' ];
-	$assoc_args   = [ 'fields' => implode( ',', $table_fields ) ];
+	$assoc_args   = [ 'fields' => 'field,count' ];
 
 	WP_CLI::log( 'Total counts of each field type (control):' );
 	$formatter = new WP_CLI\Formatter( $assoc_args, $table_fields );
-	$formatter->display_items( $table_values );
+	$formatter->display_items( get_fields() );
 }
 
 if ( ! defined( 'WP_CLI' ) ) {

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -9,7 +9,6 @@ namespace Genesis\CustomBlocks\Cli;
 
 use WP_CLI;
 use WP_Query;
-use Genesis\CustomBlocks\Blocks\Block;
 
 /**
  * Gets the field types (controls) and their counts.
@@ -27,10 +26,14 @@ function get_fields() {
 
 	$field_histogram = [];
 	foreach ( $block_query->posts as $post ) {
-		$block = new Block( $post->ID );
-		foreach ( $block->fields as $field ) {
-			$field_histogram[ $field->control ] = ! empty( $field_histogram[ $field->control ] ) && is_int( $field_histogram[ $field->control ] )
-				? $field_histogram[ $field->control ] + 1
+		$block_json = json_decode( $post->post_content, true );
+		if ( ! isset( $block_json[ 'genesis-custom-blocks/' . $post->post_name ]['fields'] ) ) {
+			break;
+		}
+
+		foreach ( $block_json[ 'genesis-custom-blocks/' . $post->post_name ]['fields'] as $field_name => $field ) {
+			$field_histogram[ $field['control'] ] = ! empty( $field_histogram[ $field['control'] ] ) && is_int( $field_histogram[ $field['control'] ] )
+				? $field_histogram[ $field['control'] ] + 1
 				: 1;
 		}
 	}

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Queries for the blocks on the site.
+ *
+ * phpcs:ignoreFile
+ * @package Genesis\CustomBlocks
+ */
+
+namespace Genesis\CustomBlocks\Cli;
+
+use WP_CLI;
+use WP_Query;
+use Genesis\CustomBlocks\Blocks\Block;
+
+/**
+ * Gets the field types (controls) and their counts.
+ *
+ * @return array[] An array of associative arrays, with keys of 'field' and 'count'.
+ */
+function get_fields() {
+	$field_histogram = [];
+	$block_query     = new WP_Query( [ 'post_type' =>'genesis_custom_block' ] );
+	foreach( $block_query->posts as $post ) {
+		$block = new Block( $post->ID );
+		foreach( $block->fields as $field ) {
+			$field_histogram[ $field->control ] = ! empty( $field_histogram[ $field->control ] ) && is_int( $field_histogram[ $field->control ] )
+				? $field_histogram[ $field->control ] + 1
+				: 1;
+		}
+	}
+
+	$table_fields = [];
+	foreach ( $field_histogram as $field => $count ) {
+		$table_fields[] = compact( 'field', 'count' );
+	}
+
+	return $table_fields;
+}
+
+/**
+ * Queries the blocks on the site and logs the results.
+ */
+function query_blocks() {
+	$post_count = wp_count_posts( 'genesis_custom_block' );
+	WP_CLI::log( sprintf( 'There are %1$d GCB blocks', $post_count->publish ) );
+	WP_CLI::log( "\n" );
+
+	$table_values = get_fields();
+	$table_fields = [ 'field', 'count' ];
+	$assoc_args   = [
+		'fields' => implode( ',', $table_fields ),
+		'format' => 'table',
+	];
+
+	$formatter = new WP_CLI\Formatter( $assoc_args, $table_fields );
+	$formatter->display_items( $table_values );
+}
+
+if ( ! defined( 'WP_CLI' ) ) {
+ 	echo "Please run this with WP-CLI: wp eval-file bin/query-blocks.php\n";
+	exit( 1 );
+}
+
+query_blocks();

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -66,10 +66,7 @@ function query_blocks() {
 
 	$table_values = get_fields();
 	$table_fields = [ 'field', 'count' ];
-	$assoc_args   = [
-		'fields' => implode( ',', $table_fields ),
-		'format' => 'table',
-	];
+	$assoc_args   = [ 'fields' => implode( ',', $table_fields ) ];
 
 	WP_CLI::log( 'Total counts of each field type (control):' );
 	$formatter = new WP_CLI\Formatter( $assoc_args, $table_fields );

--- a/bin/query-blocks.php
+++ b/bin/query-blocks.php
@@ -48,6 +48,11 @@ function get_fields() {
  */
 function query_blocks() {
 	$post_count = wp_count_posts( 'genesis_custom_block' );
+	if ( empty( $post_count->publish ) ) {
+		WP_CLI::log( 'There is no GCB block' );
+		return;
+	}
+
 	WP_CLI::log( sprintf( 'There are %1$d GCB blocks', $post_count->publish ) );
 	WP_CLI::log( "\n" );
 


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Adds a simple file to run with WP-CLI: 
<img width="352" alt="number-blocks" src="https://user-images.githubusercontent.com/4063887/119416118-94b7a600-bcb8-11eb-862d-a695d050cc94.png">

* The scope of [GF-3081](https://wpengine.atlassian.net/browse/GF-3081) is just a POC, this code will probably live elsewhere

Fixes [GF-3081](https://wpengine.atlassian.net/browse/GF-3081)

#### Testing instructions
1. `wp eval-file bin/query-blocks.php`
2. Expected: something like:
```sh
There are 4 GCB blocks


+--------------+-------+
| field        | count |
+--------------+-------+
| classic_text | 2     |
| post         | 1     |
| rich_text    | 1     |
| taxonomy     | 1     |
| user         | 1     |
| repeater     | 1     |
| text         | 5     |
| textarea     | 2     |
| url          | 1     |
| image        | 2     |
| toggle       | 1     |
+--------------+-------+
```

If the plugin is deactivated, it should be:

```sh
Genesis Custom Blocks is not active
There is no GCB block
```
