### PR TITLE
Update the URL for 'Learn More' link

### DIFF
--- a/js/src/edit-block/components/template-editor.js
+++ b/js/src/edit-block/components/template-editor.js
@@ -31,7 +31,7 @@ const TemplateEditor = () => {
 	const { getFields } = useField();
 	const { templateCss = '', templateMarkup = '' } = block;
 	const exampleFieldName = getFields()?.shift()?.name ?? 'foo-baz';
-	const urlTemplateDocumentation = 'https://developer.wpengine.com/genesis-custom-blocks/get-started/add-a-custom-block-to-your-website-content/';
+	const urlTemplateDocumentation = 'https://developer.wpengine.com/genesis-custom-blocks/get-started/create-your-first-custom-block/';
 
 	useEffect( () => {
 		addCompleter( {


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Changes the URL of the 'Learn More' link to `https://developer.wpengine.com/genesis-custom-blocks/get-started/create-your-first-custom-block/`
<img width="656" alt="the-learn-more-link" src="https://user-images.githubusercontent.com/4063887/123655791-f1950780-d7f4-11eb-980b-ef728e2f7e18.png">

* As Susan mentioned

#### Testing instructions
1. `composer install && npm i && npm run build`
2. `/wp-admin` > Custom Blocks > Add New
3. Click 'Template Editor' and 'Learn More': 
<img width="656" alt="the-learn-more-link" src="https://user-images.githubusercontent.com/4063887/123656130-4173ce80-d7f5-11eb-8851-b7aad5bc23f2.png">
4. Expected: It opens a new tab at the URL of https://developer.wpengine.com/genesis-custom-blocks/get-started/create-your-first-custom-block/
