### PR TITLE
Bump the version to 1.3.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+### 1.3.0 - 2021-07-20 ###
+
+InnerBlocks and File field
+
 ### 1.2.0 - 2021-06-28 ###
 
 New Template Editor, Editor Preview, and Front-end Preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### 1.3.0 - 2021-07-20 ###
 
-InnerBlocks and File field
+InnerBlocks, File field, WP 5.8 compatibility
+
+* Add InnerBlocks, allowing any block inside a GCB block. [PR 68](https://github.com/studiopress/genesis-custom-blocks/pull/68)
+* Add a file field, like for .pdf or .zip files. [PR 74](https://github.com/studiopress/genesis-custom-blocks/pull/74)
+* In WP 5.8, prevent a PHP notice by using the new filter 'block_categories_all'. [PR 85](https://github.com/studiopress/genesis-custom-blocks/pull/85) 
 
 ### 1.2.0 - 2021-06-28 ###
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.4
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "genesis-custom-blocks",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-custom-blocks",
   "title": "Genesis Custom Blocks",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Genesis Custom Blocks",
   "license": "GPL-2.0-or-later",

--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -76,6 +76,7 @@ class Loader extends ComponentAbstract {
 		add_action( 'init', [ $this, 'dynamic_block_loader' ] );
 		add_filter( 'rest_endpoints', [ $this, 'add_rest_method' ] );
 
+		// TODO: once 'Requires at least' is bumped to 5.8, delete these conditionals and just use 'block_categories_all'.
 		if ( is_wp_version_compatible( '5.8' ) ) {
 			add_filter( 'block_categories_all', [ $this, 'register_categories' ] );
 		} else {

--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -72,10 +72,15 @@ class Loader extends ComponentAbstract {
 	 */
 	public function register_hooks() {
 		add_action( 'enqueue_block_editor_assets', [ $this, 'editor_assets' ] );
-		add_filter( 'block_categories', [ $this, 'register_categories' ] );
 		add_action( 'init', [ $this, 'retrieve_blocks' ] );
 		add_action( 'init', [ $this, 'dynamic_block_loader' ] );
 		add_filter( 'rest_endpoints', [ $this, 'add_rest_method' ] );
+
+		if ( is_wp_version_compatible( '5.8' ) ) {
+			add_filter( 'block_categories_all', [ $this, 'register_categories' ] );
+		} else {
+			add_filter( 'block_categories', [ $this, 'register_categories' ] );
+		}
 	}
 
 	/**

--- a/tests/php/Integration/TestPostCapabilities.php
+++ b/tests/php/Integration/TestPostCapabilities.php
@@ -47,7 +47,6 @@ class TestPostCapabilities extends \WP_UnitTestCase {
 		$this->block_post = new BlockPost();
 		$this->block_post->set_plugin( genesis_custom_blocks() );
 		$this->block_post->register_post_type();
-		$this->block_post->add_caps();
 		$this->post_id = $this->factory()->post->create( [ 'post_type' => $this->post_type_slug ] );
 	}
 
@@ -121,6 +120,7 @@ class TestPostCapabilities extends \WP_UnitTestCase {
 	public function test_user_capability( $user_role, $capability, $expected ) {
 		set_current_screen( 'edit-post' );
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => $user_role ] ) );
+		$this->block_post->add_caps();
 
 		$this->assertEquals( $expected, current_user_can( $capability, $this->post_id ) );
 	}

--- a/tests/php/Unit/Blocks/TestLoader.php
+++ b/tests/php/Unit/Blocks/TestLoader.php
@@ -101,7 +101,7 @@ class TestLoader extends AbstractTemplate {
 		$this->instance->register_hooks();
 
 		$this->assertEquals( 10, has_action( 'enqueue_block_editor_assets', [ $this->instance, 'editor_assets' ] ) );
-		$this->assertEquals( 10, has_filter( 'block_categories', [ $this->instance, 'register_categories' ] ) );
+		$this->assertEquals( 10, has_filter( 'block_categories_all', [ $this->instance, 'register_categories' ] ) );
 		$this->assertEquals( 10, has_action( 'init', [ $this->instance, 'retrieve_blocks' ] ) );
 		$this->assertEquals( 10, has_action( 'init', [ $this->instance, 'dynamic_block_loader' ] ) );
 		$this->assertEquals( 10, has_filter( 'rest_endpoints', [ $this->instance, 'add_rest_method' ] ) );


### PR DESCRIPTION
#### Changes
* Bump the version
* Conditionally use the new `'block_categories_all'` filter


Do not merge without https://github.com/studiopress/genesis-custom-blocks/pull/74

#### Testing instructions
1. A sanity check of the code
2. No functional testing needed.
