### PR TITLE
Prevent PHP notice on Widgets page

### DIFF
--- a/js/src/block-editor/controls/test/file.js
+++ b/js/src/block-editor/controls/test/file.js
@@ -16,6 +16,10 @@ jest.mock( '@wordpress/api-fetch', () => {
 	} );
 } );
 
+jest.mock( '@wordpress/data/build/components/use-select', () =>
+	jest.fn( () => false )
+);
+
 // @todo: remove this when the console warning no longer appears.
 // Expected mock function not to be called but it was called with:
 // ["wp.components.DropZoneProvider is deprecated. Note: wp.component.DropZone no longer needs a provider. wp.components.DropZoneProvider is safe to remove from your code."]

--- a/js/src/block-editor/controls/test/image.js
+++ b/js/src/block-editor/controls/test/image.js
@@ -16,6 +16,10 @@ jest.mock( '@wordpress/api-fetch', () => {
 	} );
 } );
 
+jest.mock( '@wordpress/data/build/components/use-select', () =>
+	jest.fn( () => false )
+);
+
 // @todo: remove this when the console warning no longer appears.
 // Expected mock function not to be called but it was called with:
 // ["wp.components.DropZoneProvider is deprecated. Note: wp.component.DropZone no longer needs a provider. wp.components.DropZoneProvider is safe to remove from your code."]

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -63,7 +63,7 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	const mediaUpload = useSelect( ( select ) => {
 		// @ts-ignore The function isn't in the declaration file.
 		const { getSettings } = select( blockEditorStore );
-		return getSettings().mediaUpload || legacyMediaUpload;
+		return getSettings()?.mediaUpload || legacyMediaUpload;
 	} );
 
 	useEffect( () => {

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { mediaUpload } from '@wordpress/editor';
+import { mediaUpload as legacyMediaUpload } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -56,6 +57,13 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	const media = useSelect( ( select ) => {
 		// @ts-ignore The function isn't in the declaration file.
 		return select( 'core' ).getMedia( fieldValue );
+	} );
+
+	/* @type {function|undefined} */
+	const mediaUpload = useSelect( ( select ) => {
+		// @ts-ignore The function isn't in the declaration file.
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().mediaUpload || legacyMediaUpload;
 	} );
 
 	useEffect( () => {

--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -126,7 +126,7 @@ class Loader extends ComponentAbstract {
 		wp_enqueue_script(
 			$js_handle,
 			$this->assets['url']['entry'],
-			$js_config['dependencies'],
+			[],
 			$js_config['version'],
 			true
 		);


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* On `wp-admin/widgets.php`, prevents the PHP notice from enqueuing `wp-editor`
* The dependencies are included in the build because [npm run build](https://github.com/studiopress/genesis-custom-blocks/blob/a2aedc453819b3396a1e286e83b98decb315839f/package.json#L112) has the flag [--webpack-no-externals](https://xwp.co/javascript-dependencies-wordpress-blocks/)
* Gets `mediaUpload()` from `core/block-editor`, not `core/editor`, if it's available there.

## Before
>( ! ) Notice: wp_enqueue_script() was called <strong>incorrectly</strong>. "wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets). Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.8.0.) in /wp-includes/functions.php on line 5535
--
<img width="1043" alt="notice-hisdf" src="https://user-images.githubusercontent.com/4063887/126373129-1e1511f6-d6b5-45fa-a758-e51691027e01.png">

## After 
No notice:
<img width="712" alt="another-notice" src="https://user-images.githubusercontent.com/4063887/126373238-2f9f871e-ed6a-4181-bf6e-c95de8a5744d.png">

<br class="Apple-interchange-newline">

#### Testing instructions
1. `wp core update --version=5.8-RC4`
2. Go to `/wp-admin` > Widgets
3. Expected: There's no PHP notice 
