### PR TITLE
Bump the version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### 1.4.0 - 2021-10-14 ###
 
-Add a modal option to make longer blocks easier, fix for widgets.php
-
 * Optional modal for editor fields. [PR 93](https://github.com/studiopress/genesis-custom-blocks/pull/93)
 * Fix ServerSideRender in /wp-admin/widgets.php. [PR 94](https://github.com/studiopress/genesis-custom-blocks/pull/94)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog ##
 
-### 1.4.0 - 2021-9-30 ###
+### 1.4.0 - 2021-10-14 ###
 
 Add a modal option to make longer blocks easier, fix for widgets.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog ##
 
-### 1.40 - 2021-9-30 ###
+### 1.4.0 - 2021-9-30 ###
 
 Add a modal option to make longer blocks easier, fix for widgets.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog ##
 
+### 1.40 - 2021-9-30 ###
+
+Add a modal option to make longer blocks easier, fix for widgets.php
+
+* Optional modal for editor fields. [PR 93](https://github.com/studiopress/genesis-custom-blocks/pull/93)
+* Fix ServerSideRender in /wp-admin/widgets.php. [PR 94](https://github.com/studiopress/genesis-custom-blocks/pull/94)
+
 ### 1.3.1 - 2021-08-26 ###
 
 Fix for fields with long strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### 1.4.0 - 2021-10-14 ###
 
 * Optional modal for editor fields. [PR 93](https://github.com/studiopress/genesis-custom-blocks/pull/93)
-* Fix ServerSideRender in /wp-admin/widgets.php. [PR 94](https://github.com/studiopress/genesis-custom-blocks/pull/94)
 
 ### 1.3.1 - 2021-08-26 ###
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Let the plugin do the heavy lifting so you can use the built-in editor, or famil
 As an alternative to the built-in editor, there are simple functions, ready to render and work with the data stored through your custom block fields.
 
 ## Currently available block fields ##
-* Inner Blocks field
+* Inner Blocks Field
 * File Field
 * Text Field
 * Image Field

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
 Tags: gutenberg, blocks, block editor, fields, template
-Requires at least: 5.4
+Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 1.3.1
+Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.3.1
+ * Version: 1.4.0
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "genesis-custom-blocks",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6847,6 +6847,12 @@
           "requires": {
             "icss-utils": "^5.0.0"
           }
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+          "dev": true
         },
         "sass-loader": {
           "version": "10.2.0",
@@ -21902,12 +21908,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@2.2.1-beta-1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-custom-blocks",
   "title": "Genesis Custom Blocks",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Genesis Custom Blocks",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Bumps the version to `1.4.0` to prepare for the release on Thursday, October 14th
* Adds a CHANGELOG entry.
* Bumps the minimum WP version to `5.7`


#### Testing instructions
1. `php bin/verify-versions.php`
2. Expected: 'Success! All of the version numbers are the same, and there's a CHANGELOG.md entry.'