### PR TITLE
Update the CI config to use non-deprecated images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
 executors:
   php:
     docker:
-      - image: circleci/php:7.4.5-cli-node
+      - image: cimg/php:7.4.5-node
 
 commands:
   set-up-packages:
@@ -39,7 +39,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '14.18.1'
+          node-version: '14.15.0'
       - nodegit-workaround
       - set-up-packages
       - run: npm run lint
@@ -49,7 +49,7 @@ jobs:
       php-version:
         type: string
     docker:
-      - image: circleci/php:<< parameters.php-version >>-cli-node
+      - image: cimg/php:<< parameters.php-version >>-node
         environment:
           WP_TESTS_DIR: ~/project/wordpress-develop/tests/phpunit
       - image: mysql:5.7
@@ -61,13 +61,8 @@ jobs:
           MYSQL_ROOT_PASSWORD: wordpress
     steps:
       - checkout
-      - run:
-          name: Installing PHP extensions
-          command: |
-            sudo apt-get update && sudo apt-get install libpng-dev
-            sudo docker-php-ext-install mysqli gd
       - node/install:
-          node-version: '14.18.1'
+          node-version: '14.15.0'
       - nodegit-workaround
       - run:
           name: Installing WordPress and setting up tests
@@ -94,7 +89,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '14.18.1'
+          node-version: '14.15.0'
       - nodegit-workaround
       - run: HUSKY_SKIP_INSTALL=1 npm ci && npm run test:js -- --maxWorkers=2
 
@@ -106,7 +101,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install php php-xml
       - install-composer
       - node/install:
-          node-version: '14.18.1'
+          node-version: '14.15.0'
       - nodegit-workaround
       - set-up-packages
       - run: npm run wp-env start && npm run test:e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '14.15.0'
+          node-version: '14.18.1'
       - nodegit-workaround
       - set-up-packages
       - run: npm run lint
@@ -62,7 +62,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '14.15.0'
+          node-version: '14.18.1'
       - nodegit-workaround
       - run:
           name: Installing WordPress and setting up tests
@@ -89,7 +89,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '14.15.0'
+          node-version: '14.18.1'
       - nodegit-workaround
       - run: HUSKY_SKIP_INSTALL=1 npm ci && npm run test:js -- --maxWorkers=2
 
@@ -101,7 +101,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install php php-xml
       - install-composer
       - node/install:
-          node-version: '14.15.0'
+          node-version: '14.18.1'
       - nodegit-workaround
       - set-up-packages
       - run: npm run wp-env start && npm run test:e2e

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
     "require": {
         "php": "^5.6 || ^7"
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "require-dev": {
         "brain/monkey": "2.4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,6 @@
     "require": {
         "php": "^5.6 || ^7"
     },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
-    },
     "require-dev": {
         "brain/monkey": "2.4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
@@ -21,6 +16,11 @@
         "squizlabs/php_codesniffer": "3.5.3",
         "wp-coding-standards/wpcs": "2.2.0",
         "phpunit/phpunit": "7.5.2"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,12 +6848,6 @@
             "icss-utils": "^5.0.0"
           }
         },
-        "prettier": {
-          "version": "npm:wp-prettier@2.2.1-beta-1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-          "dev": true
-        },
         "sass-loader": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.2.0.tgz",
@@ -21908,6 +21902,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.2.1-beta-1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Props @mindctrl, this is mainly copied from https://github.com/wpengine/atlas-content-modeler/pull/377

#### Testing instructions
* Not needed, this really only touches testing and dev files
