### PR TITLE
Allow more users to see images that admins added

### DIFF
--- a/js/src/block-editor/controls/test/file.js
+++ b/js/src/block-editor/controls/test/file.js
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/api-fetch', () => {
 } );
 
 jest.mock( '@wordpress/data/build/components/use-select', () =>
-	jest.fn( () => false )
+	() => () => {}
 );
 
 /**

--- a/js/src/block-editor/controls/test/image.js
+++ b/js/src/block-editor/controls/test/image.js
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/api-fetch', () => {
 } );
 
 jest.mock( '@wordpress/data/build/components/use-select', () =>
-	jest.fn( () => () => 52 )
+	() => () => {}
 );
 
 /**

--- a/js/src/block-editor/controls/test/image.js
+++ b/js/src/block-editor/controls/test/image.js
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/api-fetch', () => {
 } );
 
 jest.mock( '@wordpress/data/build/components/use-select', () =>
-	jest.fn( () => false )
+	jest.fn( () => () => 52 )
 );
 
 /**

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -41,12 +41,6 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 
 /**
- * @typedef {Object} GetImageReturn The return value of the hook.
- * @property {string} source_url The url of the image.
- * @property {string} alt The alt attribute of the image.
- */
-
-/**
  * Gets the image context and functions to change it.
  *
  * @param {number|string} fieldValue The current field value.
@@ -66,7 +60,10 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 		 * Gets the image.
 		 *
 		 * @param {number | string} imageId The id of the image.
-		 * @return {GetImageReturn | undefined} The image, if any.
+		 * @return {{
+		 *   source_url: string,
+		 *   alt: string,
+		 * } | undefined} The image, if any.
 		 */
 		return ( imageId ) =>
 			// @ts-ignore This function is wrong in the declaration file.

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -55,7 +55,7 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const [ mediaAlt, setImageAlt ] = useState( '' );
 
-	const getImage = useSelect( ( select ) => {
+	const getMedia = useSelect( ( select ) => {
 		/**
 		 * Gets the image.
 		 *
@@ -80,13 +80,13 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	useEffect( () => {
 		let timeout;
 		if ( ! media?.source_url ) {
-			const image = getImage( fieldValue );
+			const image = getMedia( fieldValue );
 			if ( image ) {
 				setMedia( image );
 			} else {
 				timeout = setTimeout(
 					() => {
-						setMedia( getImage( fieldValue ) );
+						setMedia( getMedia( fieldValue ) );
 					},
 					500
 				);
@@ -94,7 +94,7 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 		}
 
 		return () => clearTimeout( timeout );
-	}, [ media, fieldValue, getImage, setMedia ] );
+	}, [ media, fieldValue, getMedia, setMedia ] );
 
 	useEffect( () => {
 		if ( media?.source_url ) {

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -88,7 +88,7 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 					() => {
 						setMedia( getImage( fieldValue ) );
 					},
-					1000
+					500
 				);
 			}
 		}

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -57,17 +57,17 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 
 	const getMediaFile = useSelect( ( select ) => {
 		/**
-		 * Gets the image.
+		 * Gets the media file.
 		 *
-		 * @param {number | string} imageId The id of the image.
+		 * @param {number | string} mediaId The id of the media.
 		 * @return {{
 		 *   source_url: string,
 		 *   alt: string,
 		 * } | undefined} The image, if any.
 		 */
-		return ( imageId ) =>
+		return ( mediaId ) =>
 			// @ts-ignore This function is wrong in the declaration file.
-			select( 'core' ).getEntityRecord( 'postType', 'attachment', imageId, { context: 'embed' } );
+			select( 'core' ).getEntityRecord( 'postType', 'attachment', mediaId, { context: 'embed' } );
 	} );
 
 	/* @type {function|undefined} */

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -55,7 +55,7 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const [ mediaAlt, setImageAlt ] = useState( '' );
 
-	const getMedia = useSelect( ( select ) => {
+	const getMediaFile = useSelect( ( select ) => {
 		/**
 		 * Gets the image.
 		 *
@@ -80,13 +80,13 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	useEffect( () => {
 		let timeout;
 		if ( ! media?.source_url ) {
-			const image = getMedia( fieldValue );
+			const image = getMediaFile( fieldValue );
 			if ( image ) {
 				setMedia( image );
 			} else {
 				timeout = setTimeout(
 					() => {
-						setMedia( getMedia( fieldValue ) );
+						setMedia( getMediaFile( fieldValue ) );
 					},
 					500
 				);
@@ -94,7 +94,7 @@ const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 		}
 
 		return () => clearTimeout( timeout );
-	}, [ media, fieldValue, getMedia, setMedia ] );
+	}, [ media, fieldValue, getMediaFile, setMedia ] );
 
 	useEffect( () => {
 		if ( media?.source_url ) {

--- a/js/src/block-editor/hooks/useMedia.js
+++ b/js/src/block-editor/hooks/useMedia.js
@@ -56,7 +56,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 const useMedia = ( fieldValue, onChange, allowedTypes ) => {
 	const defaultImageSrc = '';
-	const [ media, setMedia ] = useState( {} );
+	const [ media, setMedia ] = useState( { alt: undefined, source_url: undefined } );
 	const [ mediaSrc, setMediaSrc ] = useState( defaultImageSrc );
 	const [ isUploading, setIsUploading ] = useState( false );
 	const [ mediaAlt, setImageAlt ] = useState( '' );


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Addresses an issue where an Author can't see images that an Admin added to an Image field
* From a [support topic](https://wordpress.org/support/topic/possible-user-role-bug/) that I neglected for too long

#### Steps To Test

1. Create a new GCB block 
2. Add an Image field to it
3. Publish the block 
4. Create a new post
5. Add the new block that you created
6. Add an image to the image field:  <img width="874" alt="Screen Shot 2021-11-17 at 12 37 52 PM" src="https://user-images.githubusercontent.com/4063887/149044038-1648c0f8-ec04-4938-bba8-5d1b533fbcbb.png">
7. Click 'Save draft'
8. Reload the page
9. Expected: the image displays, just like before: 
![Screen Shot 2022-01-24 at 12 29 32 AM](https://user-images.githubusercontent.com/4063887/150733142-661f7621-9d0a-492a-bddd-50879fd38f31.png)


#### Original Steps To Replicate 

1. Create a new GCB block as an Admin
2. Add an Image field to it
3. Publish the block 
4. Log into `/wp-admin` as an Author
5. Create a new post
6. Add the new block that you created
7. Add an image to the image field:  
<img width="874" alt="Screen Shot 2021-11-17 at 12 37 52 PM" src="https://user-images.githubusercontent.com/4063887/149044038-1648c0f8-ec04-4938-bba8-5d1b533fbcbb.png">

 8. Save the post

 9. Log out

 9. Log into `/wp-admin` as an Admin again

10. Go back to the post

11. Change the image in the Image field:  <img width="861" alt="Screen Shot 2021-11-17 at 12 40 13 PM(1)" src="https://user-images.githubusercontent.com/4063887/149044102-2635c1fa-f1da-40b8-b491-89ef25ef3715.png">

12. Save the post:

13. Log out

14. Log into `/wp-admin` as an Author

15. Go back to the post

16. Expected: The block has the image that was recently added

17. Actual: The block shows no image:  
<img width="878" alt="Screen Shot 2021-11-17 at 12 42 28 PM(1)" src="https://user-images.githubusercontent.com/4063887/149044160-fafc0800-98be-44a2-a931-66633290e390.png"> 

But the post_content has the image in the block attributes:

```
<!-- wp:genesis-custom-blocks/test-image {"image":2851} /-->
```

With this PR, the 'Expected' and 'Actual' should be the same

