### PR TITLE
Update e2e tests so they pass with WP `5.9`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,14 +104,7 @@ jobs:
           node-version: '14.18.1'
       - nodegit-workaround
       - set-up-packages
-      - run:
-          name: Start environment
-          command: |
-            npm run wp-env start
-            npm run wp-env run cli wp core upgrade --version=5.9-RC3
-            echo "The version is:"
-            npm run wp-env run cli wp core upgrade --version=5.9-RC3
-            npm run test:e2e
+      - run: npm run wp-env start && npm run test:e2e
       - run:
           command: |
             if [ -d artifacts ]; then cp -r artifacts /tmp/; fi;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,8 @@ jobs:
           command: |
             npm run wp-env start
             npm run wp-env run cli wp core upgrade --version=5.9-RC3
+            echo "The version is:"
+            npm run wp-env run cli wp core upgrade --version=5.9-RC3
             npm run test:e2e
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,12 @@ jobs:
           node-version: '14.18.1'
       - nodegit-workaround
       - set-up-packages
-      - run: npm run wp-env start && npm run test:e2e
+      - run:
+          name: Start environment
+          command |
+            npm run wp-env start
+            wp-env run cli wp core upgrade --version=5.9-RC3
+            npm run test:e2e
       - run:
           command: |
             if [ -d artifacts ]; then cp -r artifacts /tmp/; fi;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: Start environment
           command: |
             npm run wp-env start
-            wp-env run cli wp core upgrade --version=5.9-RC3
+            npm run wp-env run cli wp core upgrade --version=5.9-RC3
             npm run test:e2e
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - set-up-packages
       - run:
           name: Start environment
-          command |
+          command: |
             npm run wp-env start
             wp-env run cli wp core upgrade --version=5.9-RC3
             npm run test:e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -5055,16 +5055,96 @@
       }
     },
     "@wordpress/e2e-test-utils": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-5.1.4.tgz",
-      "integrity": "sha512-2ex6XvMtCLZymzOhmtDDO+zMVal+04yyl/+jKPeP35t5RpFqxeYHdRjvcTXA3L3Rx2Rib/z5U7IHvZHMlcAUzA==",
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-5.4.10.tgz",
+      "integrity": "sha512-JRp1f7uQ9INpN3t0x4X07P3uBMwaitou9lvYWpDwVsHRcDn21NyFpVYbsX/T63ADIpvcqIhql58RnkVJRUWYxg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@wordpress/keycodes": "^3.0.0",
-        "@wordpress/url": "^3.0.0",
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/api-fetch": "^5.2.6",
+        "@wordpress/keycodes": "^3.2.4",
+        "@wordpress/url": "^3.3.1",
+        "form-data": "^4.0.0",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@wordpress/api-fetch": {
+          "version": "5.2.6",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.6.tgz",
+          "integrity": "sha512-AG8KdCHwtYJWR38AAU7nEI+UbumUSqSBthQj3rShLUVyFbYGkQdpwXJJG6vFj7FjIp41zljiyj3K1Fh3cqdaAw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/i18n": "^4.2.4",
+            "@wordpress/url": "^3.3.1"
+          }
+        },
+        "@wordpress/hooks": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
+          "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
+          "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/hooks": "^3.2.2",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.2.4.tgz",
+          "integrity": "sha512-o6/WFO8Amoyk3r3JtCJ1ctt0bLfvCqyfV7SdA39QDtAe8ufIkDNRwyQOjzaVMbHznNCuBL1FhClPzGy+RH0o9w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/i18n": "^4.2.4",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@wordpress/url": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.3.1.tgz",
+          "integrity": "sha512-lEuvkNjPoVuzYy0zn6n9gfMdNlHJW36EsPI2yDzMICjIAV5lRv1/uOg2Ls3lbDaRR2vm1FAiMpB2RAMzfR8Nfg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@wordpress/e2e-tests": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@wordpress/dependency-extraction-webpack-plugin": "3.1.3",
     "@wordpress/dom": "3.0.0",
     "@wordpress/dom-ready": "3.0.0",
-    "@wordpress/e2e-test-utils": "5.1.4",
+    "@wordpress/e2e-test-utils": "5.4.10",
     "@wordpress/e2e-tests": "2.1.6",
     "@wordpress/edit-post": "4.0.0",
     "@wordpress/editor": "10.0.0",

--- a/tests/e2e/specs/all-fields.js
+++ b/tests/e2e/specs/all-fields.js
@@ -121,7 +121,7 @@ describe( 'AllFields', () => {
 		// Create the custom block (a 'genesis_custom_block' post).
 		const customPostType = 'genesis_custom_block';
 		await visitAdminPage( 'post-new.php', `?post_type=${ customPostType }` );
-		await findByLabelText( await getDocument( page ), 'Block title' );
+		await ( await findByLabelText( await getDocument( page ), 'Block title' ) ).click();
 		await page.keyboard.type( blockName );
 
 		const $editBlockDocument = await getDocument( page );
@@ -187,7 +187,7 @@ describe( 'AllFields', () => {
 		await page.click( `[value=${ fields.radio.value }` );
 
 		// Click away from the block so the <ServerSideRender> displays.
-		await ( await findByRole( $blockEditorDocument, 'button', { name: 'Document' } ) ).click();
+		await ( await findByRole( $blockEditorDocument, 'textbox', { name: /add title/i } ) ).click();
 
 		const getExpectedText = ( templateFunction, fieldName ) => {
 			return `Here is the result of calling ${ templateFunction } for ${ fields[ fieldName ].name }: ${ fields[ fieldName ].value }`;


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Update e2e tests so they pass on `5.9-RC3`
* Luckily, GCB itself already works with `5.9-RC3`, including Twenty Twentytwo

#### Testing Instructions
* Not needed, this only touches testing files
* Just a quick sanity check of the code would be great