### PR TITLE
Allow previewing `InnerBlocks` in the block editor

### DIFF
--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -9,10 +9,10 @@ import * as React from 'react';
 import { serialize } from '@wordpress/blocks';
 // @ts-ignore Declaration file is outdated.
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { Modal, Notice } from '@wordpress/components';
+import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
 import ServerSideRender from '@wordpress/server-side-render';
 
@@ -37,15 +37,6 @@ const Edit = ( { block, blockProps } ) => {
 	const hasEditorField = getFieldsAsArray( block.fields ).some(
 		( field ) => ! field.location || EDITOR_LOCATION === field.location
 	);
-
-	const innerBlockFields = getFieldsAsArray( block.fields ).filter(
-		( field ) => 'inner_blocks' === field.control
-	);
-
-	const hasInnerBlocksField = Boolean( innerBlockFields.length );
-	const innerBlocksFieldLabel = hasInnerBlocksField
-		? innerBlockFields[ 0 ].label
-		: '';
 
 	/**
 	 * Gets whether the passed block has a selected InnerBlock.
@@ -92,17 +83,6 @@ const Edit = ( { block, blockProps } ) => {
 					? <EditorForm block={ block } blockProps={ blockProps } />
 					: (
 						<>
-							{ hasInnerBlocksField
-								? (
-									<Notice status="info" isDismissible={ false }>
-										{ sprintf(
-											/* translators: %1$s: the field name */
-											__( 'The field %1$s will not display in this preview, but will display on the front-end', 'genesis-custom-blocks' ),
-											innerBlocksFieldLabel
-										) }
-									</Notice>
-								) : null
-							}
 							<div
 								role="button"
 								tabIndex={ 0 }

--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -41,10 +41,8 @@ const Edit = ( { block, blockProps } ) => {
 	/** @type {Object[] | undefined} */
 	const innerBlocks = useSelect(
 		( select ) => {
-			const store = select( blockEditorStore.name );
-
 			// @ts-ignore Type definition is outdated.
-			return store.getBlock( blockProps.clientId )?.innerBlocks;
+			return select( blockEditorStore.name ).getBlock( blockProps.clientId )?.innerBlocks;
 		},
 		[ blockProps.clientId ]
 	);

--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -38,6 +38,17 @@ const Edit = ( { block, blockProps } ) => {
 		( field ) => ! field.location || EDITOR_LOCATION === field.location
 	);
 
+	/** @type {Object[] | undefined} */
+	const innerBlocks = useSelect(
+		( select ) => {
+			const store = select( blockEditorStore.name );
+
+			// @ts-ignore Type definition is outdated.
+			return store.getBlock( blockProps.clientId )?.innerBlocks;
+		},
+		[ blockProps.clientId ]
+	);
+
 	/**
 	 * Gets whether the passed block has a selected InnerBlock.
 	 *
@@ -63,16 +74,6 @@ const Edit = ( { block, blockProps } ) => {
 			return hasSelectedInnerBlock( store.getBlock( blockProps.clientId ), store.getSelectedBlock() );
 		},
 		[ blockProps.clientId, blockProps.isSelected ]
-	);
-
-	const innerBlocks = useSelect(
-		( select ) => {
-			const store = select( blockEditorStore.name );
-
-			// @ts-ignore Type definition is outdated.
-			return store.getBlock( blockProps.clientId )?.innerBlocks;
-		},
-		[ blockProps.clientId ]
 	);
 
 	return (
@@ -126,7 +127,10 @@ const Edit = ( { block, blockProps } ) => {
 									attributes={ blockProps.attributes }
 									className="genesis-custom-blocks-editor__ssr"
 									httpMethod="POST"
-									urlQueryArgs={ { inner_blocks: serialize( innerBlocks ) } }
+									urlQueryArgs={ { inner_blocks: innerBlocks
+										? encodeURIComponent( serialize( innerBlocks ) )
+										: '',
+									} }
 								/>
 							</div>
 						</>

--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -6,6 +6,7 @@ import * as React from 'react';
 /**
  * WordPress dependencies
  */
+import { serialize } from '@wordpress/blocks';
 // @ts-ignore Declaration file is outdated.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { Modal, Notice } from '@wordpress/components';
@@ -73,6 +74,16 @@ const Edit = ( { block, blockProps } ) => {
 		[ blockProps.clientId, blockProps.isSelected ]
 	);
 
+	const innerBlocks = useSelect(
+		( select ) => {
+			const store = select( blockEditorStore.name );
+
+			// @ts-ignore Type definition is outdated.
+			return store.getBlock( blockProps.clientId )?.innerBlocks;
+		},
+		[ blockProps.clientId ]
+	);
+
 	return (
 		<>
 			<GcbInspector blockProps={ blockProps } block={ block } />
@@ -135,6 +146,7 @@ const Edit = ( { block, blockProps } ) => {
 									attributes={ blockProps.attributes }
 									className="genesis-custom-blocks-editor__ssr"
 									httpMethod="POST"
+									urlQueryArgs={ { inner_blocks: serialize( innerBlocks ) } }
 								/>
 							</div>
 						</>

--- a/php/Blocks/Controls/InnerBlocks.php
+++ b/php/Blocks/Controls/InnerBlocks.php
@@ -50,6 +50,10 @@ class InnerBlocks extends ControlAbstract {
 	 */
 	public function validate( $value, $echo ) {
 		unset( $value, $echo );
-		return genesis_custom_blocks()->loader->get_data( 'content' );
+		$content = genesis_custom_blocks()->loader->get_data( 'content' );
+
+		return empty( $content )
+			? filter_input( INPUT_GET, 'inner_blocks', FILTER_SANITIZE_STRING )
+			: $content;
 	}
 }

--- a/php/Blocks/Controls/InnerBlocks.php
+++ b/php/Blocks/Controls/InnerBlocks.php
@@ -53,7 +53,7 @@ class InnerBlocks extends ControlAbstract {
 		$content = genesis_custom_blocks()->loader->get_data( 'content' );
 
 		return empty( $content )
-			? filter_input( INPUT_GET, 'inner_blocks', FILTER_SANITIZE_STRING )
+			? urldecode( filter_input( INPUT_GET, 'inner_blocks', FILTER_SANITIZE_STRING ) )
 			: $content;
 	}
 }

--- a/tests/php/Unit/Blocks/Controls/TestInnerBlocks.php
+++ b/tests/php/Unit/Blocks/Controls/TestInnerBlocks.php
@@ -5,9 +5,9 @@
  * @package Genesis\CustomBlocks
  */
 
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\setUp;
 use function Brain\Monkey\tearDown;
-use function Brain\Monkey\Functions\expect;
 use Genesis\CustomBlocks\Blocks\Controls\InnerBlocks;
 
 /**
@@ -25,7 +25,7 @@ class TestInnerBlocks extends \WP_UnitTestCase {
 	public $instance;
 
 	/**
-	 * Set up before each test.
+	 * Set up.
 	 *
 	 * @inheritdoc
 	 */
@@ -99,7 +99,7 @@ class TestInnerBlocks extends \WP_UnitTestCase {
 	 *
 	 * @covers \Genesis\CustomBlocks\Blocks\Controls\InnerBlocks::validate()
 	 */
-	public function test_validate_inner_blocks_ignores_query_arg_when_content_present() {
+	public function test_validate_inner_blocks_returns_content_when_non_empty() {
 		$content = 'Here is some example inner blocks content';
 		add_filter(
 			'genesis_custom_blocks_data_content',

--- a/tests/php/Unit/Blocks/Controls/TestInnerBlocks.php
+++ b/tests/php/Unit/Blocks/Controls/TestInnerBlocks.php
@@ -5,6 +5,9 @@
  * @package Genesis\CustomBlocks
  */
 
+use function Brain\Monkey\setUp;
+use function Brain\Monkey\tearDown;
+use function Brain\Monkey\Functions\expect;
 use Genesis\CustomBlocks\Blocks\Controls\InnerBlocks;
 
 /**
@@ -22,13 +25,25 @@ class TestInnerBlocks extends \WP_UnitTestCase {
 	public $instance;
 
 	/**
-	 * Setup.
+	 * Set up before each test.
 	 *
 	 * @inheritdoc
 	 */
 	public function setUp() {
 		parent::setUp();
+		setUp();
 		$this->instance = new InnerBlocks();
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		remove_all_filters( 'genesis_custom_blocks_data_content' );
+		tearDown();
+		parent::tearDown();
 	}
 
 	/**
@@ -60,5 +75,85 @@ class TestInnerBlocks extends \WP_UnitTestCase {
 		];
 
 		$this->assert_correct_settings( $expected_settings, $this->instance->settings );
+	}
+
+	/**
+	 * Test validate with inner blocks in the content.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Controls\InnerBlocks::validate()
+	 */
+	public function test_validate_with_content() {
+		$content = '<p>Here is example inner blocks content</p>';
+		add_filter(
+			'genesis_custom_blocks_data_content',
+			function() use ( $content ) {
+				return $content;
+			}
+		);
+
+		$this->assertEquals( $content, $this->instance->validate( '', false ) );
+	}
+
+	/**
+	 * Test that validate returns the content when it is non-empty.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Controls\InnerBlocks::validate()
+	 */
+	public function test_validate_inner_blocks_ignores_query_arg_when_content_present() {
+		$content = 'Here is some example inner blocks content';
+		add_filter(
+			'genesis_custom_blocks_data_content',
+			function() use ( $content ) {
+				return $content;
+			}
+		);
+
+		expect( 'filter_input' )
+			->never()
+			->with(
+				INPUT_GET,
+				'inner_blocks',
+				FILTER_SANITIZE_STRING
+			);
+
+		$this->assertEquals( $content, $this->instance->validate( '', false ) );
+	}
+
+	/**
+	 * Test validate with inner blocks in a query arg.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Controls\InnerBlocks::validate()
+	 */
+	public function test_validate_inner_blocks_in_query_arg() {
+		$inner_blocks = 'Here is some example inner blocks content';
+		expect( 'filter_input' )
+			->once()
+			->with(
+				INPUT_GET,
+				'inner_blocks',
+				FILTER_SANITIZE_STRING
+			)
+			->andReturn( $inner_blocks );
+
+		$this->assertEquals( $inner_blocks, $this->instance->validate( '', false ) );
+	}
+
+	/**
+	 * Test validate with inner blocks in a query arg, when it prepares to echo.
+	 *
+	 * @covers \Genesis\CustomBlocks\Blocks\Controls\InnerBlocks::validate()
+	 */
+	public function test_validate_inner_blocks_in_query_arg_echoed() {
+		$inner_blocks = 'Here is some example inner blocks content';
+		expect( 'filter_input' )
+			->once()
+			->with(
+				INPUT_GET,
+				'inner_blocks',
+				FILTER_SANITIZE_STRING
+			)
+			->andReturn( $inner_blocks );
+
+		$this->assertEquals( $inner_blocks, $this->instance->validate( '', true ) );
 	}
 }


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

Fixes https://github.com/studiopress/genesis-custom-blocks/issues/96 and [GF-3302](https://wpengine.atlassian.net/browse/GF-3302)

#### Changes
* Allow previewing `InnerBlocks` in the block editor, where there was no preview before. This is an often-mentioned bug.
* Remove the notice that you can't preview `InnerBlocks`

#### Testing Instructions
1. `composer i && npm i && npm run dev`
2. `/wp-admin` > Custom Blocks > Add New
3. Create a new block
4. Add a new field
5. Give it a 'Field Type' of 'Inner Blocks': <img width="1039" alt="Screen Shot 2022-03-09 at 11 18 53 AM" src="https://user-images.githubusercontent.com/4063887/157495835-b6ff4e4a-710f-4193-9908-81a024468c7b.png">
6. Click 'Template Editor'
7. Enter `{{new-field}}`: <img width="1005" alt="Screen Shot 2022-03-09 at 11 22 54 AM" src="https://user-images.githubusercontent.com/4063887/157496607-6970c27f-bb0e-4be4-b803-81d3bebdf818.png">
8. Click 'Publish'
9. Create a new post
10. Add the block you just created: <img width="997" alt="Screen Shot 2022-03-09 at 11 25 11 AM" src="https://user-images.githubusercontent.com/4063887/157496835-51e6104f-e02f-47cd-a757-e525ca7c876b.png">
11. Add some blocks to Inner Blocks: <img width="1048" alt="Screen Shot 2022-03-09 at 11 26 27 AM" src="https://user-images.githubusercontent.com/4063887/157497105-a54fb450-986a-4034-a4dd-bd7a5c1fa83a.png">
12. Click away from the block so the preview displays: <img width="1057" alt="Screen Shot 2022-03-09 at 11 27 28 AM" src="https://user-images.githubusercontent.com/4063887/157497328-b8fdd5d8-714e-48c0-8ffb-fe7c46c1e2b8.png">
13. Expected: The preview includes the blocks you added to Inner Blocks: <img width="1021" alt="Screen Shot 2022-03-09 at 11 28 57 AM" src="https://user-images.githubusercontent.com/4063887/157497564-dd1e4bd1-64e0-47e6-a96e-c627d2586fb4.png">


