### PR TITLE
Add some sanitization back in

### DIFF
--- a/php/Admin/Upgrade.php
+++ b/php/Admin/Upgrade.php
@@ -52,10 +52,8 @@ class Upgrade extends ComponentAbstract {
 			return;
 		}
 
-		$page = filter_input( INPUT_GET, 'page' );
-
 		// Enqueue scripts and styles on the edit screen of the Block post type.
-		if ( $this->slug === $page ) {
+		if ( filter_input( INPUT_GET, 'page' ) === $this->slug ) {
 			wp_enqueue_style(
 				$this->slug,
 				$this->plugin->get_url( 'css/admin.upgrade.css' ),

--- a/php/Blocks/Controls/InnerBlocks.php
+++ b/php/Blocks/Controls/InnerBlocks.php
@@ -53,7 +53,7 @@ class InnerBlocks extends ControlAbstract {
 		$content = genesis_custom_blocks()->loader->get_data( 'content' );
 
 		return empty( $content )
-			? urldecode( filter_input( INPUT_GET, 'inner_blocks' ) )
+			? urldecode( wp_strip_all_tags( filter_input( INPUT_GET, 'inner_blocks' ) ) )
 			: $content;
 	}
 }

--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -330,9 +330,7 @@ class Loader extends ComponentAbstract {
 		$type = 'block';
 
 		// This is hacky, but the editor doesn't send the original request along.
-		$context = filter_input( INPUT_GET, 'context' );
-
-		if ( 'edit' === $context ) {
+		if ( 'edit' === filter_input( INPUT_GET, 'context' ) ) {
 			$type = [ 'preview', 'block' ];
 		}
 


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Background
In https://github.com/studiopress/genesis-custom-blocks/pull/119, I removed `FILTER_SANITIZE_STRING` flags for PHP 8.1 compatibility

## Changes
* Add sanitization in 1 case, and remove the variables in 2 cases


## Testing instructions
Not needed, just a sanity check would be great