### PR TITLE
Bump the version to `1.5.1`, add a `CHANGELOG` entry 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+### 1.5.1 - 2022-08-09 ###
+* PHP 8.1 compatibility fixes. [PR 119](https://github.com/studiopress/genesis-custom-blocks/pull/119)
+
 ### 1.5.0 - 2022-03-24 ###
 
 * Allow previewing InnerBlocks in the block editor. [PR 114](https://github.com/studiopress/genesis-custom-blocks/pull/114)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 5.6
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl
 

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "genesis-custom-blocks",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-custom-blocks",
   "title": "Genesis Custom Blocks",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Genesis Custom Blocks",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
Bumps the version in preparation for the release next week.

## Changes
* Bump version to 1.5.1
* Add a CHANGELOG entry

Fixes [GF-3467](https://wpengine.atlassian.net/browse/GF-3467)


## Testing instructions
1. `php bin/verify-versions.php`
2. Expected: Success! All of the version numbers are the same, and there's a CHANGELOG.md entry. 
