### PR TITLE
In `svn` deployment, ensure Node is `14`, not `16`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - checkout
+      - node/install
       - run:
           command: |
             BUILD_VERSION=$(grep 'Version:' genesis-custom-blocks.php | cut -f4 -d' ')


### PR DESCRIPTION
* The previous deployment failed because it [expected](https://app.circleci.com/pipelines/github/studiopress/genesis-custom-blocks/1582/workflows/201d84a6-c44f-4fbd-a9a4-59bfeff6b106/jobs/12711) Node `14`, but got `16`
* So this pins it to `14`
* `node/install` will get `14` from [.nvmrc](https://github.com/studiopress/genesis-custom-blocks/blob/fa775954a74d9adcb24938ad4f7df885be2d2744/.nvmrc)

<!--- Please summarize this PR in the title above -->

## Testing instructions
Not needed 