### PR TITLE
Run the new version-check job from the wp-svn orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   node: circleci/node@5.0
   php: circleci/php@1.1
-  wp-svn: studiopress/wp-svn@dev:alpha
+  wp-svn: studiopress/wp-svn@0.1
 
 references:
   PLUGIN_PATH: &PLUGIN_PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,9 @@ workflows:
               only: /.*/
       - wp-svn/check-versions:
           changelog-file: CHANGELOG.md
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - svn-deploy:
           context: genesis-svn
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   node: circleci/node@5.0
   php: circleci/php@1.1
-  wp-svn: studiopress/wp-svn@0.1
+  wp-svn: studiopress/wp-svn@dev:alpha
 
 references:
   PLUGIN_PATH: &PLUGIN_PATH
@@ -124,6 +124,8 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - wp-svn/version-check:
+          changelog-file: CHANGELOG.md
       - php-tests:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,6 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      - wp-svn/check-versions:
-          changelog-file: CHANGELOG.md
       - php-tests:
           filters:
             tags:
@@ -145,6 +143,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - wp-svn/check-versions:
+          changelog-file: CHANGELOG.md
       - svn-deploy:
           context: genesis-svn
           requires:
@@ -152,6 +152,7 @@ workflows:
             - js-tests
             - e2e-tests
             - lint
+            - wp-svn/check-versions
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      - wp-svn/version-check:
+      - wp-svn/check-versions:
           changelog-file: CHANGELOG.md
       - php-tests:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,8 @@ workflows:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
-          branches:
-            ignore: /.*/
+            branches:
+              ignore: /.*/
       - svn-deploy:
           context: genesis-svn
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,11 @@ workflows:
               only: /.*/
       - wp-svn/check-versions:
           changelog-file: CHANGELOG.md
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
       - svn-deploy:
           context: genesis-svn
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,8 @@ workflows:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
+          branches:
+            ignore: /.*/
       - svn-deploy:
           context: genesis-svn
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,11 +145,6 @@ workflows:
               only: /.*/
       - wp-svn/check-versions:
           changelog-file: CHANGELOG.md
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
       - svn-deploy:
           context: genesis-svn
           requires:


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Changes
Run the new [check-versions job](https://github.com/studiopress/wp-svn-orb/pull/17) from the wp-svn orb on tagging a release:

<img width="471" alt="Screen Shot 2022-09-27 at 10 34 22 PM" src="https://user-images.githubusercontent.com/4063887/192682180-e3da1bc0-1a3b-4ff2-9ab7-edb51f23b6a0.png">

We won't need that job when we're not deploying, so it only runs it then.

As part of my 15Five development goal, not in this sprint 😄 

## Testing Steps
Not needed. Just make sure nothing looks horribly wrong. If this job goes bad, it'll simply stop the pipeline, it won't do anything else.