### PR TITLE
Bump 'Tested up to' to `6.1`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Installing WordPress and setting up tests
           command: |
-            git clone -b 6.1 git://develop.git.wordpress.org/ wordpress-develop
+            git clone git://develop.git.wordpress.org/ wordpress-develop
             cp wordpress-develop/wp-tests-config-sample.php wordpress-develop/wp-tests-config.php
             sed -i 's/localhost/127.0.0.1/g' wordpress-develop/wp-tests-config.php
             sed -i 's/yourpasswordhere/<insert password here>/g' wordpress-develop/wp-tests-config.php
@@ -93,8 +93,6 @@ jobs:
           name: Runnning e2e tests
           command: |
             npm run wp-env start
-            npm run wp-env run cli 'wp core upgrade --version=6.1-RC3'
-            npm run wp-env run cli 'wp core version'
             npm run test:e2e
       - store_artifacts:
           path: /tmp/artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Installing WordPress and setting up tests
           command: |
-            git clone git://develop.git.wordpress.org/ wordpress-develop
+            git clone -b 6.1 git://develop.git.wordpress.org/ wordpress-develop
             cp wordpress-develop/wp-tests-config-sample.php wordpress-develop/wp-tests-config.php
             sed -i 's/localhost/127.0.0.1/g' wordpress-develop/wp-tests-config.php
             sed -i 's/yourpasswordhere/<insert password here>/g' wordpress-develop/wp-tests-config.php
@@ -93,6 +93,8 @@ jobs:
           name: Runnning e2e tests
           command: |
             npm run wp-env start
+            npm run wp-env run cli 'wp core upgrade --version=6.1'
+            npm run wp-env run cli 'wp core version'
             npm run test:e2e
       - store_artifacts:
           path: /tmp/artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           name: Runnning e2e tests
           command: |
             npm run wp-env start
-            npm run wp-env run cli 'wp core upgrade --version=6.1'
+            npm run wp-env run cli 'wp core upgrade --version=6.1-RC3'
             npm run wp-env run cli 'wp core version'
             npm run test:e2e
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.7
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 5.6
 Stable tag: 1.5.1
 License: GPLv2 or later


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Changes
* Bump 'Tested up to' to 6.1

## Testing instructions
Not needed, e2e and PHP tests passed on WP `6.1`