### PR TITLE
Bump 'Tested up to' to 6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ workflows:
               only: /.*/
           matrix:
             parameters:
-              php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+              php-version: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
       - js-tests:
           filters:
             tags:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.7
-Tested up to: 6.1
+Tested up to: 6.2
 Requires PHP: 5.6
 Stable tag: 1.5.1
 License: GPLv2 or later

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpen
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.7
 Tested up to: 6.2
-Requires PHP: 5.6
+Requires PHP: 7.0
 Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

## Changes
* Bump 'Tested up to' to 6.2
* Change PHP requirement from 5.6 to 7.0
* This is lazy on my part. PHPUnit tests failed on PHP [5.6](https://app.circleci.com/pipelines/github/studiopress/genesis-custom-blocks/1612/workflows/f36c61dd-b2bb-4f01-8a0b-56b5e6dd94c2/jobs/13060), and I don't know how to fix them. 
* PHP 5.6 has been EOL [for 4 years](https://www.php.net/eol.php). 

## Testing instructions
Not needed, already tested in https://github.com/studiopress/genesis-custom-blocks/pull/140