### PR TITLE
Make it easier to edit custom blocks CSS

### DIFF
--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -457,7 +457,7 @@ class Loader extends ComponentAbstract {
 				'genesis-custom-blocks__global-styles',
 				$stylesheet_url,
 				[],
-				wp_get_theme()->get( 'Version' )
+				filemtime( $stylesheet_path )
 			);
 		}
 	}


### PR DESCRIPTION
We like to create custom blocks with Genesis. However when we edit the blocks/blocks.css file in the theme folder we have to clear the browser cache each time and tell that to our clients.

We would much prefer is that file would be always loaded fresh from the server - at least if there was a change in the content.

That's why we did a miniature change which puts the file modification timestamp into that stylesheet URL.

This way a browser is forced to load the new file if you make modifications to your custom blocks CSS file.

Very important specially if you use a CDN.

<!--- Please summarize this PR in the title above -->

## Changes
* ensured the custom blocks.css file URL gets the query argument which changes when the file is modified

## Testing instructions
* check that your `wp-content/themes/monochrome-pro/blocks/blocks.css` loads with a timestamp in URL query, like `https://example.com/wp-content/themes/monochrome-pro/blocks/blocks.css?ver=1690892560`
