### PR TITLE
fix block preview rendering of innerBlocks

### DIFF
--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -77,10 +77,6 @@ const Edit = ( { block, blockProps } ) => {
 	const blockRenderAttributes = {};
 	blockRenderAttributes.attributes = blockProps.attributes;
 	blockRenderAttributes.inner_blocks = innerBlocks ? serialize( innerBlocks ) : '';
-	/*
-		attributes: ,
-		inner_blocks: innerBlocks ? serialize(innerBlocks) : ''
-	}; */
 	return (
 		<>
 			<GcbInspector blockProps={ blockProps } block={ block } />

--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -74,6 +74,13 @@ const Edit = ( { block, blockProps } ) => {
 		[ blockProps.clientId, blockProps.isSelected ] // eslint-disable-line react-hooks/exhaustive-deps
 	);
 
+	const blockRenderAttributes = {};
+	blockRenderAttributes.attributes = blockProps.attributes;
+	blockRenderAttributes.inner_blocks = innerBlocks ? serialize( innerBlocks ) : '';
+	/*
+		attributes: ,
+		inner_blocks: innerBlocks ? serialize(innerBlocks) : ''
+	}; */
 	return (
 		<>
 			<GcbInspector blockProps={ blockProps } block={ block } />
@@ -122,13 +129,9 @@ const Edit = ( { block, blockProps } ) => {
 								}
 								<ServerSideRender
 									block={ `genesis-custom-blocks/${ block.name }` }
-									attributes={ blockProps.attributes }
+									attributes={ blockRenderAttributes }
 									className="genesis-custom-blocks-editor__ssr"
 									httpMethod="POST"
-									urlQueryArgs={ { inner_blocks: innerBlocks
-										? encodeURIComponent( serialize( innerBlocks ) )
-										: '',
-									} }
 								/>
 							</div>
 						</>


### PR DESCRIPTION
## Changes
* modifying the render request to include inner blocks as post param to allow big blocks to render without 413 errors
* render full block instead of only part of it as block-renderer does not allow inner blocks at the moment

## Testing instructions
Go to the editor and add a block with inner blocks check if the preview is rendering