### PR TITLE
Fix `phpcs` error from `function` not having a space after it

### DIFF
--- a/php/Admin/EditBlock.php
+++ b/php/Admin/EditBlock.php
@@ -206,7 +206,7 @@ class EditBlock extends ComponentAbstract {
 			'template-file',
 			[
 				'callback'            => [ $this, 'get_template_file_response' ],
-				'permission_callback' => function() {
+				'permission_callback' => function () {
 					return current_user_can( self::CABAPILITY );
 				},
 				'args'                => [

--- a/php/Admin/Onboarding.php
+++ b/php/Admin/Onboarding.php
@@ -103,7 +103,7 @@ class Onboarding extends ComponentAbstract {
 
 			add_action(
 				'add_meta_boxes',
-				function() use ( $slug ) {
+				function () use ( $slug ) {
 					remove_meta_box( 'block_template', $slug, 'normal' );
 				},
 				20

--- a/php/Blocks/TemplateEditor.php
+++ b/php/Blocks/TemplateEditor.php
@@ -29,7 +29,7 @@ class TemplateEditor {
 	public function render_markup( $markup ) {
 		$rendered = preg_replace_callback(
 			'#{{(\S+?)}}#',
-			static function( $matches ) {
+			static function ( $matches ) {
 				ob_start();
 				block_field( $matches[1] );
 				return ob_get_clean();

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -61,7 +61,7 @@ class Plugin extends PluginAbstract {
 
 		register_activation_hook(
 			$this->get_file(),
-			function() {
+			function () {
 				$onboarding = new Onboarding();
 				$onboarding->plugin_activation();
 			}

--- a/tests/e2e/plugins/testing-blocks/testing-blocks.php
+++ b/tests/e2e/plugins/testing-blocks/testing-blocks.php
@@ -14,7 +14,7 @@ use function Genesis\CustomBlocks\add_field;
 
 add_filter(
 	'genesis_custom_blocks_template_path',
-	static function( $path ) {
+	static function ( $path ) {
 		unset( $path );
 		return __DIR__;
 	}
@@ -22,7 +22,7 @@ add_filter(
 
 add_action(
 	'genesis_custom_blocks_add_blocks',
-	static function() {
+	static function () {
 		$url_block_slug  = 'test-url';
 		$text_block_slug = 'test-text';
 

--- a/tests/php/Integration/Helpers/AbstractAttribute.php
+++ b/tests/php/Integration/Helpers/AbstractAttribute.php
@@ -115,7 +115,7 @@ abstract class AbstractAttribute extends \WP_UnitTestCase {
 		// Ensure that get_stylesheet_directory() returns the theme in the mock filesystem.
 		add_filter(
 			'stylesheet_directory',
-			function() use ( $mock_theme_directory ) {
+			function () use ( $mock_theme_directory ) {
 				return $mock_theme_directory;
 			}
 		);

--- a/tests/php/Integration/TestTemplateEditorOutput.php
+++ b/tests/php/Integration/TestTemplateEditorOutput.php
@@ -142,7 +142,7 @@ class TestTemplateEditorOutput extends AbstractAttribute {
 
 		add_filter(
 			'genesis_custom_blocks_available_blocks',
-			static function( $blocks ) use ( $block, $block_config ) {
+			static function ( $blocks ) use ( $block, $block_config ) {
 				return array_merge(
 					$blocks,
 					[ "genesis-custom-blocks/{$block->name}" => $block_config ]

--- a/tests/php/Unit/Admin/TestImport.php
+++ b/tests/php/Unit/Admin/TestImport.php
@@ -164,7 +164,7 @@ class TestImport extends AbstractTemplate {
 		$_FILES['import'] = $files_import;
 		add_filter(
 			'wp_handle_upload',
-			function( $upload ) use ( $file ) {
+			function ( $upload ) use ( $file ) {
 				unset( $upload );
 				return array_merge(
 					$file,
@@ -227,7 +227,7 @@ class TestImport extends AbstractTemplate {
 		remove_all_filters( 'wp_handle_upload' );
 		add_filter(
 			'wp_handle_upload',
-			function() use ( $file ) {
+			function () use ( $file ) {
 				return array_merge(
 					$file,
 					[
@@ -468,7 +468,7 @@ class TestImport extends AbstractTemplate {
 		register_block_type(
 			$block_namespace,
 			[
-				'render_callback' => function() {},
+				'render_callback' => function () {},
 			]
 		);
 

--- a/tests/php/Unit/Blocks/Controls/TestInnerBlocks.php
+++ b/tests/php/Unit/Blocks/Controls/TestInnerBlocks.php
@@ -86,7 +86,7 @@ class TestInnerBlocks extends \WP_UnitTestCase {
 		$content = '<p>Here is example inner blocks content</p>';
 		add_filter(
 			'genesis_custom_blocks_data_content',
-			function() use ( $content ) {
+			function () use ( $content ) {
 				return $content;
 			}
 		);
@@ -103,7 +103,7 @@ class TestInnerBlocks extends \WP_UnitTestCase {
 		$content = 'Here is some example inner blocks content';
 		add_filter(
 			'genesis_custom_blocks_data_content',
-			function() use ( $content ) {
+			function () use ( $content ) {
 				return $content;
 			}
 		);

--- a/tests/php/Unit/Blocks/TestLoader.php
+++ b/tests/php/Unit/Blocks/TestLoader.php
@@ -131,7 +131,7 @@ class TestLoader extends AbstractTemplate {
 		$this->assertFalse( $this->instance->get_data( $attributes_key ) );
 
 		$attributes    = [ 'bar' => 'baz' ];
-		$data_callback = static function( $data, $key ) use ( $attributes_key, $attributes ) {
+		$data_callback = static function ( $data, $key ) use ( $attributes_key, $attributes ) {
 			if ( $attributes_key === $key ) {
 				return $attributes;
 			}
@@ -144,7 +144,7 @@ class TestLoader extends AbstractTemplate {
 		$this->assertEquals( $attributes, $this->instance->get_data( $attributes_key ) );
 		remove_all_filters( 'genesis_custom_blocks_data' );
 
-		$data_callback_for_key = static function( $data ) use ( $attributes ) {
+		$data_callback_for_key = static function ( $data ) use ( $attributes ) {
 			unset( $data );
 			return $attributes;
 		};
@@ -198,7 +198,7 @@ class TestLoader extends AbstractTemplate {
 		// Test that the do_action() call with this action runs, and that it allows enqueuing a script.
 		add_action(
 			'genesis_custom_blocks_render_template',
-			function( $block ) use ( $block_name, $slug, $script_url ) {
+			function ( $block ) use ( $block_name, $slug, $script_url ) {
 				if ( $block_name === $block->name ) {
 					wp_enqueue_script( $slug, $script_url, [], '0.1', true );
 				}
@@ -219,7 +219,7 @@ class TestLoader extends AbstractTemplate {
 
 		add_action(
 			"genesis_custom_blocks_render_template_{$block_name}",
-			function() use ( $block_name, $slug, $script_url ) {
+			function () use ( $block_name, $slug, $script_url ) {
 				wp_enqueue_script( $slug, $script_url, [], '0.1', true );
 			}
 		);
@@ -403,7 +403,7 @@ class TestLoader extends AbstractTemplate {
 		// Test that this filter changes the template used.
 		add_filter(
 			'genesis_custom_blocks_override_theme_template',
-			function( $directory ) use ( $overridden_theme_template_path ) {
+			function ( $directory ) use ( $overridden_theme_template_path ) {
 				unset( $directory );
 				return $overridden_theme_template_path;
 			}

--- a/tests/php/Unit/Helpers/AbstractTemplate.php
+++ b/tests/php/Unit/Helpers/AbstractTemplate.php
@@ -71,7 +71,7 @@ abstract class AbstractTemplate extends \WP_UnitTestCase {
 	public function tear_down() {
 		// Delete testing templates and CSS files.
 		array_map(
-			function( $file ) {
+			function ( $file ) {
 				if ( file_exists( $file ) ) {
 					wp_delete_file( $file );
 				}
@@ -81,7 +81,7 @@ abstract class AbstractTemplate extends \WP_UnitTestCase {
 
 		// Remove testing directories that were created, in reverse order.
 		array_map(
-			function( $directory ) {
+			function ( $directory ) {
 				if ( is_dir( $directory ) ) {
 					rmdir( $directory ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 				}
@@ -139,7 +139,7 @@ abstract class AbstractTemplate extends \WP_UnitTestCase {
 	 */
 	public function create_block_template_directories() {
 		array_map(
-			function( $directory ) {
+			function ( $directory ) {
 				$this->mkdir( $directory );
 			},
 			[
@@ -157,7 +157,7 @@ abstract class AbstractTemplate extends \WP_UnitTestCase {
 	 */
 	public function get_template_paths_in_theme() {
 		return array_map(
-			function( $template_location ) {
+			function ( $template_location ) {
 				return "{$this->theme_directory}/{$template_location}";
 			},
 			$this->template_locations

--- a/tests/php/Unit/TestHelpers.php
+++ b/tests/php/Unit/TestHelpers.php
@@ -44,7 +44,7 @@ class TestHelpers extends \WP_UnitTestCase {
 
 		add_filter(
 			'genesis_custom_blocks_data_attributes',
-			function( $data ) use ( $field_name, $class_key, $mock_text, $expected_class ) {
+			function ( $data ) use ( $field_name, $class_key, $mock_text, $expected_class ) {
 				if ( ! is_array( $data ) ) {
 					$data = [];
 				}
@@ -57,7 +57,7 @@ class TestHelpers extends \WP_UnitTestCase {
 
 		add_filter(
 			'genesis_custom_blocks_data_config',
-			function( $data ) use ( $field_name ) {
+			function ( $data ) use ( $field_name ) {
 				unset( $data );
 				$field_config = [ 'control' => 'text' ];
 				$block_config = [
@@ -110,7 +110,7 @@ class TestHelpers extends \WP_UnitTestCase {
 
 		add_filter(
 			'genesis_custom_blocks_data_attributes',
-			function() use ( $additional_field_name, $additional_field_value ) {
+			function () use ( $additional_field_name, $additional_field_value ) {
 				return [ $additional_field_name => $additional_field_value ];
 			}
 		);
@@ -128,7 +128,7 @@ class TestHelpers extends \WP_UnitTestCase {
 		// Don't return anything from the filter callback, to test the behavior.
 		add_filter(
 			$default_fields_filter,
-			function( $default_fields ) use ( $additional_field_name ) {
+			function ( $default_fields ) use ( $additional_field_name ) {
 				$default_fields[] = $additional_field_name;
 			}
 		);
@@ -144,7 +144,7 @@ class TestHelpers extends \WP_UnitTestCase {
 
 		add_filter(
 			$default_fields_filter,
-			function( $default_fields ) use ( $additional_field_name ) {
+			function ( $default_fields ) use ( $additional_field_name ) {
 				$default_fields[ $additional_field_name ] = 'string';
 				return $default_fields;
 			}

--- a/tests/php/Unit/TestUtil.php
+++ b/tests/php/Unit/TestUtil.php
@@ -149,7 +149,7 @@ class TestUtil extends AbstractTemplate {
 
 		add_filter(
 			'genesis_custom_blocks_template_path',
-			function( $path ) use ( $base_alternate_block_directory ) {
+			function ( $path ) use ( $base_alternate_block_directory ) {
 				unset( $path );
 				return $base_alternate_block_directory;
 			}
@@ -198,7 +198,7 @@ class TestUtil extends AbstractTemplate {
 
 		add_filter(
 			'genesis_custom_blocks_allowed_svg_tags',
-			function( $allowed_tags ) use ( $additional_tag_name, $additional_tag_attributes ) {
+			function ( $allowed_tags ) use ( $additional_tag_name, $additional_tag_attributes ) {
 				$allowed_tags[ $additional_tag_name ] = $additional_tag_attributes;
 				return $allowed_tags;
 			}


### PR DESCRIPTION
## Changes
* Makes CI/CD pass again by fixing a `phpcs` error

## Testing instructions
Not needed