### PR TITLE
Remove white space under color setting in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Genesis Custom Blocks
 
-Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
+Contributors: lukecarbis, pesonn, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.7
 Tested up to: 6.3

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -40,7 +40,6 @@ $font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans
 			.components-base-control__field {
 				margin: 0 !important;
 				width: 100%;
-				height: 100%;
 			}
 
 			&.genesis-custom-blocks-color-popover {


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://wpeng.in/cla/) with WP Engine.

## Changes
* Remove height for color base control, as it's increasing the height and other settings get moved out of the sidebar.

## Testing instructions
Example: 
![Genesis Custom Blocks Color Setting](https://github.com/studiopress/genesis-custom-blocks/assets/43933988/5845a995-c53b-4e82-b86c-3f60d226be4c)
