### PR TITLE
Enqueue `block-editor.js` dependencies that I didn't enqueue before

### DIFF
--- a/php/Blocks/Loader.php
+++ b/php/Blocks/Loader.php
@@ -134,7 +134,7 @@ class Loader extends ComponentAbstract {
 		wp_enqueue_script(
 			$js_handle,
 			$this->assets['url']['entry'],
-			[],
+			$js_config['dependencies'],
 			$js_config['version'],
 			true
 		);


### PR DESCRIPTION
## Changes
* Enqueue `block-editor.js` dependencies that I didn't enqueue before
* I actually didn't use [dist/block-editor.asset.php](https://plugins.trac.wordpress.org/browser/genesis-custom-blocks/trunk/js/dist/block-editor.asset.php?rev=2946749), nothing referenced that

Fixes #168 
