### PR TITLE
[LOC-6740] chore: bump 'tested up to' to 6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf, studiopress, wpengine
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 6.0
-Tested up to: 6.6
+Tested up to: 6.9
 Requires PHP: 7.0
 Stable tag: 1.7.1
 License: GPLv2 or later

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.7.0
+ * Version: 1.7.1
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2

--- a/genesis-custom-blocks.php
+++ b/genesis-custom-blocks.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: Genesis Custom Blocks
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.7.1
+ * Version: 1.7.0
  * Author: Genesis Custom Blocks
  * Author URI: https://studiopress.com
  * License: GPL2


### PR DESCRIPTION
To update WP.org tested version.

Already deployed to https://wordpress.org/plugins/genesis-custom-blocks/.