### PR TITLE
[LOC-6891] ci: reinstate deploy to WP.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
             cp wordpress-develop/wp-tests-config-sample.php wordpress-develop/wp-tests-config.php
             sed -i 's/localhost/127.0.0.1/g' wordpress-develop/wp-tests-config.php
             sed -i 's/yourpasswordhere/<insert password here>/g' wordpress-develop/wp-tests-config.php
-      - run: 
+      - run:
           name: Install wordpress-importer
           command: |
             cd ~/project/wordpress-develop
@@ -134,19 +134,19 @@ jobs:
       - store_artifacts:
           path: artifacts/
 
-  # svn-deploy:
-  #   executor:
-  #     name: php
-  #   steps:
-  #     - checkout
-  #     - node/install
-  #     - run:
-  #         name: "Building"
-  #         command: |
-  #           composer install -o --no-dev
-  #           npm ci
-  #           npm run build
-  #     - wp-svn/deploy-plugin
+  svn-deploy:
+    executor:
+      name: php
+    steps:
+      - checkout
+      - node/install
+      - run:
+          name: "Building"
+          command: |
+            composer install -o --no-dev
+            npm ci
+            npm run build
+      - wp-svn/deploy-plugin
 
 workflows:
   test-deploy:
@@ -174,26 +174,26 @@ workflows:
           filters:
             tags:
               only: /.*/
-      # - wp-svn/check-versions:
-      #     skip-changelog: true
-      #     filters:
-      #       tags:
-      #         only: /^\d+\.\d+\.\d+$/
-      #       branches:
-      #         only: /^release.*/
-      # - svn-deploy:
-      #     context: genesis-svn
-      #     requires:
-      #       - php-tests
-      #       - js-tests
-      #       - e2e-tests
-      #       - lint
-      #       - wp-svn/check-versions
-      #     filters:
-      #       tags:
-      #         only: /^\d+\.\d+\.\d+$/
-      #       branches:
-      #         ignore: /.*/
+      - wp-svn/check-versions:
+          skip-changelog: true
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              only: /^release.*/
+      - svn-deploy:
+          context: genesis-svn
+          requires:
+            - php-tests
+            - js-tests
+            - e2e-tests
+            - lint
+            - wp-svn/check-versions
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
       - approval-for-deploy-tested-up-to-bump:
           type: approval
           requires:


### PR DESCRIPTION
Allows us to tag to deploy to WP.org again when we're ready to.

This is ready for review, but we should wait until [LOC-6890](https://wpengine.atlassian.net/browse/LOC-6890) has been completed and merged before merging this, just to prevent accidental deploys to .org with the WPE update logic.

## Testing instructions
Code review only.

I confirmed that the YML is valid:

```sh
❯ circleci config check
Config file at .circleci/config.yml is valid.
```

## Reference
https://wpengine.atlassian.net/browse/LOC-6891