### PR TITLE
Fix modal editor always opening in WordPress 7.0+

### DIFF
--- a/js/src/block-editor/components/edit.js
+++ b/js/src/block-editor/components/edit.js
@@ -8,7 +8,7 @@ import * as React from 'react';
  */
 import { serialize } from '@wordpress/blocks';
 // @ts-ignore Declaration file is outdated.
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
 import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -37,6 +37,9 @@ const Edit = ( { block, blockProps } ) => {
 	const hasEditorField = getFieldsAsArray( block.fields ).some(
 		( field ) => ! field.location || EDITOR_LOCATION === field.location
 	);
+
+	// Required for Block API v3 - ensures isSelected and other props work correctly in iframe editor
+	const blockPropsWithWrapper = useBlockProps( { className: blockProps.className } );
 
 	/** @type {Object[] | undefined} */
 	const innerBlocks = useSelect(
@@ -77,7 +80,7 @@ const Edit = ( { block, blockProps } ) => {
 	return (
 		<>
 			<GcbInspector blockProps={ blockProps } block={ block } />
-			<div className={ blockProps.className } key={ `form-controls-${ block.name }` }>
+			<div { ...blockPropsWithWrapper } key={ `form-controls-${ block.name }` }>
 				{ ( blockProps.isSelected || isInnerBlockSelected ) && hasEditorField && ! block.displayModal
 					? <EditorForm block={ block } blockProps={ blockProps } />
 					: (

--- a/js/src/block-editor/helpers/registerBlocks.js
+++ b/js/src/block-editor/helpers/registerBlocks.js
@@ -40,6 +40,7 @@ const registerBlocks = ( genesisCustomBlocks, gcbBlocks, EditComponent ) => {
 		}
 
 		registerBlockType( blockName, {
+			apiVersion: 3,
 			title: block.title,
 			category: 'object' === typeof block.category ? block.category.slug : block.category,
 			icon: getIconComponent( block.icon ),

--- a/js/src/block-editor/helpers/test/apiVersionSync.js
+++ b/js/src/block-editor/helpers/test/apiVersionSync.js
@@ -1,0 +1,40 @@
+/**
+ * This test ensures that the API version declared in JavaScript block registration
+ * matches the API version declared in the PHP Loader class.
+ *
+ * This prevents bugs where blocks are registered with different API versions on
+ * the client (JS) and server (PHP) sides, which can cause editor issues like
+ * broken prop communication in WordPress 7.0+ iframe editor.
+ */
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+describe( 'API Version Sync', () => {
+	it( 'should have matching API versions in PHP Loader and JS registerBlocks', () => {
+		// Read the PHP Loader file
+		const phpLoaderPath = path.join( __dirname, '../../../../../php/Blocks/Loader.php' );
+		const phpContent = fs.readFileSync( phpLoaderPath, 'utf8' );
+
+		// Extract API version from PHP (looking for 'api_version' => NUMBER)
+		const phpMatch = phpContent.match( /'api_version'\s*=>\s*(\d+)/ );
+		expect( phpMatch ).not.toBeNull();
+		const phpApiVersion = parseInt( phpMatch[ 1 ], 10 );
+
+		// Read the JS registerBlocks file
+		const jsRegisterBlocksPath = path.join( __dirname, '../registerBlocks.js' );
+		const jsContent = fs.readFileSync( jsRegisterBlocksPath, 'utf8' );
+
+		// Extract API version from JS (looking for apiVersion: NUMBER)
+		const jsMatch = jsContent.match( /apiVersion:\s*(\d+)/ );
+		expect( jsMatch ).not.toBeNull();
+		const jsApiVersion = parseInt( jsMatch[ 1 ], 10 );
+
+		// They must match
+		expect( jsApiVersion ).toBe( phpApiVersion );
+		expect( jsApiVersion ).toBe( 3 ); // Also explicitly check it's v3
+	} );
+} );

--- a/js/src/block-editor/helpers/test/registerBlocks.js
+++ b/js/src/block-editor/helpers/test/registerBlocks.js
@@ -12,6 +12,7 @@ jest.mock( '@wordpress/blocks', () => {
 } );
 const Edit = () => {};
 const expectedArgs = {
+	apiVersion: 3,
 	title: expect.any( String ),
 	category: expect.any( String ),
 	icon: expect.any( Function ),


### PR DESCRIPTION
## Problem
Clicking on custom blocks always opened the modal editor instead of showing the inline editor, even when the `displayModal` option was disabled.

## Root Cause
Commit 3392dc90 upgraded only the PHP side to Block API v3, but the JavaScript registration still defaulted to v2. This version mismatch broke the `isSelected` prop in WordPress 7.0's iframe editor, causing the inline editor conditional to always fail.

Block API v3 requires `useBlockProps()` to bridge communication between the iframe and parent window.

## Solution
- Add `useBlockProps()` hook to Edit component for proper iframe prop syncing
- Declare `apiVersion: 3` in JavaScript registration to match PHP
- Add automated test to prevent PHP/JS API version mismatches in the future

## Testing
**Manual test:**
1. Create a new custom block with the "Edit in modal" option **unchecked** (default)
2. Add a field to the block (e.g., text field)
3. Create a new WordPress post and insert the block
4. When the block is selected, verify the inline editor appears with the field visible
5. Click outside the block, then click back on it - inline editor should reappear
6. Create another block with "Edit in modal" **checked** - verify clicking opens a modal instead

**Automated tests:**
- Updated existing test to verify `apiVersion: 3` is declared
- Added new test that validates PHP and JS API versions stay synchronized

## Reference

- https://wpengine.atlassian.net/browse/LOC-6912